### PR TITLE
Fixup the RAF docs

### DIFF
--- a/raf/README.md
+++ b/raf/README.md
@@ -1,7 +1,8 @@
 # RAF: Request Animation Frame
 
-Subscribe to a stream of Request Animation Frame updates with an Effection
-resource.
+Subscribe to a stream of
+[Request Animation Frame](https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)
+updates.
 
 ---
 
@@ -10,9 +11,9 @@ import { each, main, suspend } from "effection";
 import { raf } from "@effectionx/raf";
 
 await main(function* () {
-  for (const frame of yield* each(raf)) {
+  for (const timestamp of yield* each(raf)) {
     // add your handler code here
-    console.log(frame);
+    console.log(timestamp);
     yield* each.next();
   }
 });

--- a/raf/raf.ts
+++ b/raf/raf.ts
@@ -1,6 +1,6 @@
 import { createSignal, resource, type Stream } from "effection";
 /**
- * Consume RAF's as a Stream.
+ * A stream that produces animation frames.
  */
 export const raf: Stream<number, never> = resource(
   function* (provide) {


### PR DESCRIPTION
## Motivation

There were a few details that can be added to improve understanding.

## Approach

- While streams are most often implemented with resources, it is not always the case, and in any event it is an implementation detail, so remove the reference to them.

- link to the RAF docs.

- in the raf docs, they refer to the parameter pass to the callback as a `timestamp`. This adjusts the docs to use that terminology in stead.
