### PR TITLE
Downgrade effection to 3 in test-adapter

### DIFF
--- a/test-adapter/deno.json
+++ b/test-adapter/deno.json
@@ -1,10 +1,10 @@
 {
   "name": "@effectionx/test-adapter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "imports": {
-    "effection": "npm:effection@4.0.0-beta.2",
+    "effection": "npm:effection@^3",
     "@std/expect": "jsr:@std/expect@^1",
     "@std/testing": "jsr:@std/testing@^1"
   }


### PR DESCRIPTION
# Motivation

I want to start pulling out changes from #87 to make it mergable. I need test-adapter to be on v3 so I can use it as a dependency with deno-testing-bdd package that I'll publish next.

# Approach

Switch to v3 and bump minor to 0.3.0
