### PR TITLE
Eliminted all specifiers in ts files

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,11 @@
 {
   "imports": {
     "bdd": "jsr:@std/testing@1/bdd",
-    "expect": "jsr:@std/expect@1"
+    "expect": "jsr:@std/expect@1",
+    "effection": "npm:effection@^3",
+    "@deno/dnt": "jsr:@deno/dnt@0.42.3",
+    "@std/path": "jsr:@std/path@^1",
+    "zod": "npm:zod@3.23.8"
   },
   "compilerOptions": {
     "lib": [

--- a/jsonl-store/deno.json
+++ b/jsonl-store/deno.json
@@ -5,11 +5,11 @@
   "license": "MIT",
   "imports": {
     "effection": "npm:effection@4.0.0-beta.2",
-    "@std/json": "jsr:@std/json@1.0.1",
-    "@std/streams": "jsr:@std/streams@1.0.8",
-    "@std/fs": "jsr:@std/fs@1.0.4",
-    "@std/path": "jsr:@std/path@1.0.6",
-    "@std/testing": "jsr:@std/testing@1.0.5",
-    "@std/expect": "jsr:@std/expect@"
+    "@std/json": "jsr:@std/json@^1",
+    "@std/streams": "jsr:@std/streams@^1",
+    "@std/fs": "jsr:@std/fs@^1",
+    "@std/path": "jsr:@std/path@^1",
+    "@std/testing": "jsr:@std/testing@^1",
+    "@std/expect": "jsr:@std/expect@^1"
   }
 }

--- a/jsonl-store/jsonl.test.ts
+++ b/jsonl-store/jsonl.test.ts
@@ -1,14 +1,15 @@
+import { expect } from "@std/expect";
+import { dirname, join } from "@std/path";
+import { beforeEach, describe, it } from "@std/testing/bdd";
 import { each, run } from "effection";
-import { beforeEach, describe, it } from "jsr:@std/testing@1.0.5/bdd";
+import { mkdir } from "node:fs";
+import { promisify } from "node:util";
+
 import { JSONLStore } from "./jsonl.ts";
 import type { Store } from "./types.ts";
-import { expect } from "jsr:@std/expect@1.0.8";
-import { dirname, join } from "jsr:@std/path@1.0.8";
 // using promisify there because Deno's ensure doesn't work
 // correctly in Node. We should run these tests in Node
 // to make sure that it'll work in Node too.
-import { mkdir } from "node:fs";
-import { promisify } from "node:util";
 
 describe("JSONLStore", () => {
   let store: Store;

--- a/raf/deno.json
+++ b/raf/deno.json
@@ -4,6 +4,7 @@
   "exports": "./mod.ts",
   "license": "MIT",
   "imports": {
-    "effection": "npm:effection@^3"
+    "effection": "npm:effection@^3",
+    "@essentials/raf": "npm:@essentials/raf@^1.2.0"
   }
 }

--- a/raf/raf.test.ts
+++ b/raf/raf.test.ts
@@ -1,7 +1,7 @@
 import {
   caf as cancelAnimationFrame,
   raf as requestAnimationFrame,
-} from "npm:@essentials/raf@^1.2.0";
+} from "@essentials/raf";
 
 import { each, run, sleep, spawn } from "effection";
 import { describe, it } from "bdd";

--- a/signals/array.test.ts
+++ b/signals/array.test.ts
@@ -1,8 +1,8 @@
-import { describe, it } from "jsr:@std/testing@^1/bdd";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { each, run, sleep, spawn } from "effection";
 
 import { createArraySignal } from "./array.ts";
-import { each, run, sleep, spawn } from "effection";
-import { expect } from "@std/expect";
 
 describe("array signal", () => {
   it("accepts an initial value", async () => {

--- a/signals/helpers.test.ts
+++ b/signals/helpers.test.ts
@@ -1,6 +1,7 @@
-import { describe, it } from "jsr:@std/testing/bdd";
-import { expect } from "jsr:@std/expect";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 import { run, spawn } from "effection";
+
 import { createBooleanSignal } from "./boolean.ts";
 import { is } from "./helpers.ts";
 

--- a/stream-helpers/batch.test.ts
+++ b/stream-helpers/batch.test.ts
@@ -1,6 +1,6 @@
 import { each, run, sleep, spawn, withResolvers } from "effection";
-import { describe, it } from "jsr:@std/testing@^1/bdd";
-import { expect } from "jsr:@std/expect@^1";
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
 import { batch } from "./batch.ts";
 import { useFaucet } from "./test-helpers/faucet.ts";
 

--- a/stream-helpers/deno.json
+++ b/stream-helpers/deno.json
@@ -4,7 +4,10 @@
   "imports": {
     "effection": "npm:effection@^3",
     "immutable": "npm:immutable@^5",
-    "@effectionx/signals": "npm:@effectionx/signals@^0.1.0"
+    "@effectionx/signals": "npm:@effectionx/signals@^0.1.0",
+    "@std/expect": "jsr:@std/expect@^1",
+    "@std/testing": "jsr:@std/testing@^1",
+    "remeda": "npm:remeda@2.21.3"
   },
   "license": "MIT",
   "exports": {

--- a/stream-helpers/filter.test.ts
+++ b/stream-helpers/filter.test.ts
@@ -1,6 +1,7 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 import { run, sleep } from "effection";
-import { describe, it } from "jsr:@std/testing@^1/bdd";
-import { expect } from "jsr:@std/expect@^1";
+
 import { filter } from "./filter.ts";
 import { useFaucet } from "./test-helpers/faucet.ts";
 

--- a/stream-helpers/map.test.ts
+++ b/stream-helpers/map.test.ts
@@ -1,6 +1,7 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
 import { run, sleep } from "effection";
-import { describe, it } from "jsr:@std/testing@^1/bdd";
-import { expect } from "jsr:@std/expect@^1";
+
 import { map } from "./map.ts";
 import { useFaucet } from "./test-helpers/faucet.ts";
 

--- a/stream-helpers/mod.test.ts
+++ b/stream-helpers/mod.test.ts
@@ -1,15 +1,14 @@
-import { pipe } from "npm:remeda@2.21.3";
-
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { assertSpyCalls, spy } from "@std/testing/mock";
 import { each, run, sleep, spawn, withResolvers } from "effection";
-import { describe, it } from "jsr:@std/testing@^1/bdd";
-import { expect } from "jsr:@std/expect@^1";
-import { assertSpyCalls, spy } from "jsr:@std/testing@^1/mock";
+import { pipe } from "remeda";
 
 import { batch } from "./batch.ts";
 import { map } from "./map.ts";
-import { valve } from "./valve.ts";
 import { useFaucet } from "./test-helpers/faucet.ts";
 import { createTracker } from "./tracker.ts";
+import { valve } from "./valve.ts";
 
 describe("batch, valve and map composition", () => {
   it("should process data through both batch and valve", async () => {

--- a/stream-helpers/test-helpers/faucet.test.ts
+++ b/stream-helpers/test-helpers/faucet.test.ts
@@ -1,8 +1,8 @@
 import { useFaucet } from "./faucet.ts";
 import { createArraySignal, is } from "@effectionx/signals";
 
-import { describe, it } from "jsr:@std/testing@^1/bdd";
-import { expect } from "jsr:@std/expect@^1";
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
 import { each, race, run, sleep, spawn } from "effection";
 
 describe("useFaucet", () => {

--- a/stream-helpers/tracker.test.ts
+++ b/stream-helpers/tracker.test.ts
@@ -1,7 +1,7 @@
 import { each, run, sleep, spawn, withResolvers } from "effection";
-import { expect } from "jsr:@std/expect@^1";
-import { describe, it } from "jsr:@std/testing@^1/bdd";
-import { pipe } from "npm:remeda@2.21.3";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { pipe } from "remeda";
 
 import { batch } from "./batch.ts";
 import { map } from "./map.ts";

--- a/stream-helpers/valve.test.ts
+++ b/stream-helpers/valve.test.ts
@@ -1,11 +1,11 @@
-import { each, run, sleep, spawn } from "effection";
-import { describe, it } from "jsr:@std/testing@^1/bdd";
-import { assertSpyCalls, spy } from "jsr:@std/testing@^1/mock";
-
-import { expect } from "jsr:@std/expect@^1";
-import { valve } from "./valve.ts";
-import { useFaucet } from "./test-helpers/faucet.ts";
 import { createArraySignal, is } from "@effectionx/signals";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { assertSpyCalls, spy } from "@std/testing/mock";
+import { each, run, sleep, spawn } from "effection";
+
+import { useFaucet } from "./test-helpers/faucet.ts";
+import { valve } from "./valve.ts";
 
 describe("valve", () => {
   it("closes and opens the valve", async () => {

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -1,6 +1,7 @@
-import { build, emptyDir } from "jsr:@deno/dnt@0.42.3";
+import { build, emptyDir } from "@deno/dnt";
+import { join } from "@std/path";
+
 import { DenoJson } from "./lib/read-packages.ts";
-import { join } from "jsr:@std/path@^1.0.7/join";
 
 let [workspace] = Deno.args;
 if (!workspace) {

--- a/tasks/lib/read-packages.ts
+++ b/tasks/lib/read-packages.ts
@@ -1,6 +1,6 @@
-import { call, type Operation } from "npm:effection@3.2.1";
-import { resolve } from "jsr:@std/path@^1.0.6";
-import { z } from "npm:zod@3.23.8";
+import { call, type Operation } from "effection";
+import { resolve } from "@std/path";
+import { z } from "zod";
 
 export const DenoJson = z.object({
   name: z.string(),

--- a/tasks/publish-matrix.ts
+++ b/tasks/publish-matrix.ts
@@ -1,4 +1,4 @@
-import { call, main } from "npm:effection@3.2.1";
+import { call, main } from "effection";
 import { x } from "../tinyexec/mod.ts";
 import { readPackages } from "./lib/read-packages.ts";
 

--- a/test-adapter/deno.json
+++ b/test-adapter/deno.json
@@ -4,6 +4,8 @@
   "license": "MIT",
   "exports": "./mod.ts",
   "imports": {
-    "effection": "npm:effection@4.0.0-beta.2"
+    "effection": "npm:effection@4.0.0-beta.2",
+    "@std/expect": "jsr:@std/expect@^1",
+    "@std/testing": "jsr:@std/testing@^1"
   }
 }

--- a/test-adapter/test/adapter.test.ts
+++ b/test-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
-import { describe, it } from "jsr:@std/testing/bdd";
-import { expect } from "jsr:@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
 import { createTestAdapter } from "../mod.ts";
 import { createContext } from "effection";
 

--- a/watch/deno.json
+++ b/watch/deno.json
@@ -9,8 +9,10 @@
   "imports": {
     "effection": "npm:effection@^4.0.0-beta.2",
     "ignore": "npm:ignore@^7.0.3",
-    "@std/fs": "jsr:@std/fs@^1.0.11",
-    "@std/path": "jsr:@std/path@^1.0.8",
+    "@gordonb/pipe": "jsr:@gordonb/pipe@0.1.0",
+    "@std/fs": "jsr:@std/fs@^1",
+    "@std/path": "jsr:@std/path@^1",
+    "@std/assert": "jsr:@std/assert@^1",
     "chokidar": "npm:chokidar@^4.0.3",
     "zod": "npm:zod@^3.20.2",
     "zod-opts": "npm:zod-opts@0.1.8"

--- a/watch/test/watch.test.ts
+++ b/watch/test/watch.test.ts
@@ -2,8 +2,8 @@ import type { Operation, Result, Stream } from "effection";
 import { call, each, Ok, run, sleep, spawn } from "effection";
 import { describe, it as bddIt } from "bdd";
 import { expect } from "expect";
-import { assert } from "jsr:@std/assert";
-import { emptyDir } from "jsr:@std/fs/empty-dir";
+import { assert } from "@std/assert";
+import { emptyDir } from "@std/fs";
 
 // temporariy disable watch tests on linux because of
 // https://github.com/denoland/deno/issues/28041

--- a/watch/watch.ts
+++ b/watch/watch.ts
@@ -15,7 +15,7 @@ import {
   withResolvers,
 } from "effection";
 import { default as createIgnore } from "ignore";
-import { pipe } from "jsr:@gordonb/pipe@0.1.0";
+import { pipe } from "@gordonb/pipe";
 import { readFile } from "node:fs/promises";
 
 import { type Process, useProcess } from "./child-process.ts";


### PR DESCRIPTION
# Motivation

#88 is failing because Deno 2.5 now recommends using imports in deno.json instead of inline specifiers.

# Approach

Moved all specifiers into imports