### PR TITLE
Return a result from test run

### DIFF
--- a/test-adapter/deno.json
+++ b/test-adapter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectionx/test-adapter",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "imports": {


### PR DESCRIPTION
# Motivation

We need to know what the result of test execution is to integate it with bdd.

# Approach

Return a result object from runTest and bump version of test-adapter