### PR TITLE
Add license to @effectionx/bdd

### DIFF
--- a/bdd/deno.json
+++ b/bdd/deno.json
@@ -2,6 +2,7 @@
   "name": "@effectionx/bdd",
   "exports": "./mod.ts",
   "version": "0.1.0",
+  "license": "MIT",
   "imports": {
     "effection": "npm:effection@^3",
     "@effectionx/test-adapter": "npm:@effectionx/test-adapter@0.4.0",


### PR DESCRIPTION
# Motivation

`@effectionx/bdd` didn't publish because license was missing.

# Approach

Add missing license
