### PR TITLE
⬆️ Update bdd dependency on @effectionx/test-adapter

### DIFF
--- a/bdd/deno.json
+++ b/bdd/deno.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "imports": {
     "effection": "npm:effection@^3",
-    "@effectionx/test-adapter": "npm:@effectionx/test-adapter@0.4.0",
+    "@effectionx/test-adapter": "npm:@effectionx/test-adapter@^0.5.0",
     "@std/testing": "jsr:@std/testing@^1"
   }
 }


### PR DESCRIPTION
# Motivation

The `addOnetimeSetup()` method was only added in 0.5.0 so we have to depend on that version.
