### PR TITLE
👷 Don't try to publish an NPM package if it exists already

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -78,7 +78,21 @@ jobs:
 
       - run: deno run -A tasks/build-npm.ts ${{matrix.workspace}}
 
+      - name: Check if Published
+        id: checkIfPublished
+        run: |
+          PACKAGE="${{ matrix.name }}@${{ matrix.version }}"
+
+          if npm view "$PACKAGE" version 2>/dev/null; then
+            echo "$PACKAGE exists, publishing will be skipped"
+            echo "publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "$PACKAGE not found, will attempt to publish"
+            echo "publish=true" >> $GITHUB_OUTPUT
+          fi
+
       - run: npm publish --access=public --tag=latest
+        if: steps.checkIfPublished.outputs.publish == 'true'
         working-directory: ${{matrix.workspace}}/build/npm
 
   tag:


### PR DESCRIPTION
# Motivation

We have a problem when re-running task that if we try to publish a version to npm that does not exist yet, then it fails. However, we want attempts to publish to be idemponent. This will make JSR and npm behave similarly.

# Approach

This adds a check step to see if the npm package at the specified name and version already exists. If so, then we skip publishing.
