### PR TITLE
Remove NPM registry

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -74,7 +74,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.com
 
       - run: deno run -A tasks/build-npm.ts ${{matrix.workspace}}
 


### PR DESCRIPTION
# Motivation

When you specify registry-url: https://registry.npmjs.com in actions/setup-node, it automatically creates a .npmrc file with NODE_AUTH_TOKEN, which prevents npm from using OIDC authentication.

# Approach

Remove the registry-url parameter from actions/setup-node. With OIDC configured (via id-token: write permission), npm will automatically authenticate using the OIDC token instead of looking for NODE_AUTH_TOKEN.
