### PR TITLE
Enable npm OIDC publishing with provenance

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -63,10 +63,8 @@ jobs:
 
       - run: pnpm build
 
-      - run: npm publish --access=public --tag=latest
+      - run: npm publish --access=public --tag=latest --provenance
         working-directory: ${{ matrix.workspace }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   gather-tags:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
# Motivation

- Add --provenance flag to npm publish for supply chain security
- Remove NPM_TOKEN dependency in favor of pure OIDC authentication
- The id-token: write permission was already configured
