### PR TITLE
fix: use pnpm publish to resolve workspace:* references

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,7 +85,7 @@ jobs:
       # First-time publish: use token auth
       - name: Publish (first time)
         if: matrix.firstPublish == true
-        run: npm publish --access=public --tag=latest --provenance
+        run: pnpm publish --access=public --tag=latest --provenance --no-git-checks
         working-directory: ${{ matrix.workspace }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
@@ -93,7 +93,7 @@ jobs:
       # Subsequent publishes: use OIDC
       - name: Publish (OIDC)
         if: matrix.firstPublish != true
-        run: npm publish --access=public --tag=latest --provenance
+        run: pnpm publish --access=public --tag=latest --provenance --no-git-checks
         working-directory: ${{ matrix.workspace }}
 
   gather-tags:

--- a/bdd/package.json
+++ b/bdd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectionx/bdd",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",

--- a/converge/package.json
+++ b/converge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectionx/converge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",

--- a/process/package.json
+++ b/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectionx/process",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",

--- a/stream-helpers/package.json
+++ b/stream-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectionx/stream-helpers",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",

--- a/watch/package.json
+++ b/watch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectionx/watch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectionx/worker",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",


### PR DESCRIPTION
# Motivation

The publish workflow was using `npm publish` which doesn't understand pnpm's workspace protocol. This resulted in packages being published with literal `workspace:*` in their dependencies instead of resolved version numbers, making them unusable.

For example, `@effectionx/bdd` on npm currently has:
```json
"dependencies": {
  "@effectionx/test-adapter": "workspace:*"
}
```

# Approach

1. **Switch to `pnpm publish`** - pnpm automatically resolves `workspace:*` references to actual version numbers when publishing
2. **Add `--no-git-checks` flag** - Required since CI publishes from a detached HEAD, not main/master
3. **Bump affected package versions** - Triggers republish with correct dependencies:

| Package | Old Version | New Version |
|---------|-------------|-------------|
| @effectionx/bdd | 0.4.0 | 0.4.1 |
| @effectionx/converge | 0.1.0 | 0.1.1 |
| @effectionx/process | 0.7.0 | 0.7.1 |
| @effectionx/stream-helpers | 0.6.0 | 0.6.1 |
| @effectionx/watch | 0.4.0 | 0.4.1 |
| @effectionx/worker | 0.4.0 | 0.4.1 |