### PR TITLE
feat: add optional per-package bundling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ pnpm install
 ### Available Commands
 
 ```bash
-pnpm build          # Build all packages
+pnpm build          # Build all packages (TypeScript + optional bundling)
+pnpm build:tsc      # Build TypeScript only
 pnpm test           # Run all tests
 pnpm test:matrix    # Test against all supported peer dependency versions
 pnpm check          # Type-check all packages
@@ -176,6 +177,24 @@ node --env-file=../.env --test "*.test.ts"
 7. Add a `README.md` (text before `---` will be used as a description)
 8. Add your source code and export it from `mod.ts`
 9. Add doc strings to your source code - they will be used for documentation
+
+### Custom Build Steps (Optional)
+
+Most packages only need TypeScript compilation, which is handled automatically by the root `tsc --build` command. However, if your package requires additional build steps (like bundling), you can add a `build:bundle` script:
+
+```json
+{
+  "scripts": {
+    "build:bundle": "esbuild mod.ts --bundle --outfile=dist/bundle.js --format=esm"
+  }
+}
+```
+
+The build process runs in two phases:
+1. **TypeScript compilation** (`tsc --build`) - produces `.js` and `.d.ts` files in `dist/`
+2. **Bundling** (`turbo run build:bundle`) - runs only for packages with a `build:bundle` script
+
+Bundle output should go to a separate file (e.g., `dist/bundle.js`) rather than overwriting the tsc output, so consumers can choose between bundled and unbundled versions.
 
 ## Publishing
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {
-    "build": "tsc --build",
+    "build": "pnpm run build:tsc && turbo run build:bundle",
+    "build:tsc": "tsc --build",
     "check": "tsc -b --emitDeclarationOnly && tsc -p tsconfig.check.json",
     "test": "node --env-file=.env --test \"**/*.test.ts\"",
     "test:matrix": "node --env-file=.env .internal/test-matrix.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
-    "build": {
-      "outputs": ["dist/**", "*.tsbuildinfo"]
+    "build:bundle": {
+      "outputs": ["dist/**"]
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
# Motivation

Some packages need more than TypeScript compilation - they require bundling or other custom build steps. Currently, `tsc -b` at the root compiles all packages, which works well for pure TypeScript but doesn't support packages that need bundlers like esbuild, rollup, or vite.

# Approach

Introduce a two-phase build process:
1. **TypeScript compilation** (`tsc --build`) - runs first, produces `.js` and `.d.ts` files
2. **Optional bundling** (`turbo run build:bundle`) - runs only for packages with a `build:bundle` script

Changes:
- Added `build:tsc` script to root package.json for TypeScript-only builds
- Updated `build` script to run tsc then turbo bundle
- Replaced `build` task with `build:bundle` in turbo.json
- Added documentation in README for custom build steps

Packages that don't need bundling require no changes - they continue to work as before.