### PR TITLE
Add @effectionx/project-repo package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,25 @@ importers:
         specifier: ^6
         version: 6.0.6
 
+  project-repo:
+    dependencies:
+      '@effectionx/fs':
+        specifier: workspace:*
+        version: link:../fs
+      '@effectionx/process':
+        specifier: workspace:*
+        version: link:../process
+      effection:
+        specifier: ^3 || ^4
+        version: 4.0.0
+      semver:
+        specifier: ^7.6.3
+        version: 7.7.3
+    devDependencies:
+      '@effectionx/bdd':
+        specifier: workspace:*
+        version: link:../bdd
+
   raf:
     dependencies:
       effection:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
   - "effect-ts"
   - "fs"
   - "fx"
+  - "project-repo"
   - "jsonl-store"
   - "node"
   - "process"

--- a/project-repo/README.md
+++ b/project-repo/README.md
@@ -27,7 +27,11 @@ import { initWorktrees, useWorktree } from "@effectionx/project-repo";
 
 await main(function* () {
   // Initialize the worktrees directory
+  // By default, uses the current working directory as the git repository
   yield* initWorktrees("./build/worktrees");
+
+  // Or specify a different git repository
+  yield* initWorktrees("./build/worktrees", { cwd: "/path/to/repo" });
 
   // Create worktrees for different versions
   const v3Path = yield* useWorktree("v3.0.0");
@@ -67,9 +71,17 @@ import { main } from "effection";
 import { createRepo } from "@effectionx/project-repo";
 
 await main(function* () {
+  // Create a repo abstraction (uses current working directory by default)
   const repo = createRepo({
     owner: "thefrontside",
     name: "effection",
+  });
+
+  // Or specify a different git repository
+  const repo2 = createRepo({
+    owner: "thefrontside",
+    name: "effection",
+    cwd: "/path/to/repo",
   });
 
   // Get all v4.x tags
@@ -106,16 +118,22 @@ console.log(latest?.name); // "v2.0.0"
 ### Worktrees
 
 - `initWorktrees(basePath, options?)` - Initialize the worktrees base directory
+  - `options.clean` - Clean the directory before initializing (default: `true`)
+  - `options.cwd` - The git repository directory to create worktrees from
 - `useWorktree(refname)` - Get or create a worktree for a git ref
 
 ### Clones
 
 - `initClones(basePath, options?)` - Initialize the clones base directory
+  - `options.clean` - Clean the directory before initializing (default: `true`)
 - `useClone(nameWithOwner)` - Clone or use cached GitHub repository
 
 ### Repository
 
 - `createRepo(options)` - Create a repository abstraction
+  - `options.owner` - Repository owner (organization or user)
+  - `options.name` - Repository name
+  - `options.cwd` - The git repository directory to run commands in
 - `repo.tags(pattern)` - Get tags matching a regex pattern
 - `repo.latest(pattern)` - Get the latest semver tag matching a pattern
 

--- a/project-repo/README.md
+++ b/project-repo/README.md
@@ -1,0 +1,135 @@
+# @effectionx/project-repo
+
+Project repository utilities for [Effection](https://frontside.com/effection) - manage worktrees, clones, and repository tags with structured concurrency.
+
+## Installation
+
+```bash
+npm install @effectionx/project-repo
+```
+
+## Features
+
+- **Worktrees**: Create and manage git worktrees for parallel version checkouts
+- **Clones**: Clone and cache GitHub repositories
+- **Repository**: Query git tags with semver sorting
+- **Semver**: Extract and compare semantic versions from tag names
+
+## Usage
+
+### Worktrees
+
+Manage git worktrees for checking out multiple refs simultaneously:
+
+```typescript
+import { main } from "effection";
+import { initWorktrees, useWorktree } from "@effectionx/project-repo";
+
+await main(function* () {
+  // Initialize the worktrees directory
+  yield* initWorktrees("./build/worktrees");
+
+  // Create worktrees for different versions
+  const v3Path = yield* useWorktree("v3.0.0");
+  const v4Path = yield* useWorktree("v4.0.0");
+
+  console.log(`v3 at: ${v3Path}`);
+  console.log(`v4 at: ${v4Path}`);
+});
+```
+
+### Clones
+
+Clone and cache GitHub repositories:
+
+```typescript
+import { main } from "effection";
+import { initClones, useClone } from "@effectionx/project-repo";
+
+await main(function* () {
+  // Initialize the clones directory
+  yield* initClones("./build/clones");
+
+  // Clone repositories (cached if already exists)
+  const effectionPath = yield* useClone("thefrontside/effection");
+  const effectionxPath = yield* useClone("thefrontside/effectionx");
+
+  console.log(`Effection at: ${effectionPath}`);
+});
+```
+
+### Repository Tags
+
+Query and sort git tags by semver:
+
+```typescript
+import { main } from "effection";
+import { createRepo } from "@effectionx/project-repo";
+
+await main(function* () {
+  const repo = createRepo({
+    owner: "thefrontside",
+    name: "effection",
+  });
+
+  // Get all v4.x tags
+  const v4Tags = yield* repo.tags(/^v4\./);
+  console.log("v4 tags:", v4Tags.map((t) => t.name));
+
+  // Get the latest v4.x tag
+  const latest = yield* repo.latest(/^v4\./);
+  console.log(`Latest: ${latest.name}`);
+  console.log(`URL: ${latest.url}`);
+});
+```
+
+### Semver Utilities
+
+Extract and compare versions from tag names:
+
+```typescript
+import { extractVersion, findLatestSemverTag } from "@effectionx/project-repo";
+
+// Extract version from tag name
+extractVersion("v3.2.1"); // "3.2.1"
+extractVersion("release-1.0.0-beta.1"); // "1.0.0-beta.1"
+
+// Find the latest tag from a list
+const tags = [{ name: "v1.0.0" }, { name: "v2.0.0" }, { name: "v1.5.0" }];
+
+const latest = findLatestSemverTag(tags);
+console.log(latest?.name); // "v2.0.0"
+```
+
+## API
+
+### Worktrees
+
+- `initWorktrees(basePath, options?)` - Initialize the worktrees base directory
+- `useWorktree(refname)` - Get or create a worktree for a git ref
+
+### Clones
+
+- `initClones(basePath, options?)` - Initialize the clones base directory
+- `useClone(nameWithOwner)` - Clone or use cached GitHub repository
+
+### Repository
+
+- `createRepo(options)` - Create a repository abstraction
+- `repo.tags(pattern)` - Get tags matching a regex pattern
+- `repo.latest(pattern)` - Get the latest semver tag matching a pattern
+
+### Semver
+
+- `extractVersion(input)` - Extract semver from a string
+- `findLatestSemverTag(tags)` - Find the latest tag by semver
+
+## Requirements
+
+- Node.js >= 22
+- Effection ^3 || ^4
+- Git must be installed and available in PATH
+
+## License
+
+MIT

--- a/project-repo/clones.test.ts
+++ b/project-repo/clones.test.ts
@@ -1,0 +1,54 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, it } from "@effectionx/bdd";
+import {
+  emptyDir,
+  ensureDir,
+  exists,
+  readdir,
+  writeTextFile,
+} from "@effectionx/fs";
+import { expect } from "expect";
+
+import { initClones } from "./mod.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const testDir = path.join(__dirname, "test-tmp", "clones-test");
+
+describe("clones", () => {
+  beforeEach(function* () {
+    yield* emptyDir(testDir);
+  });
+
+  describe("initClones", () => {
+    it("creates the clones directory", function* () {
+      const clonesDir = path.join(testDir, "clones");
+
+      yield* initClones(clonesDir);
+
+      expect(yield* exists(clonesDir)).toBe(true);
+    });
+
+    it("cleans the directory by default", function* () {
+      const clonesDir = path.join(testDir, "clones");
+      yield* ensureDir(clonesDir);
+      yield* writeTextFile(path.join(clonesDir, "old.txt"), "old");
+
+      yield* initClones(clonesDir);
+
+      const contents = yield* readdir(clonesDir);
+      expect(contents).toHaveLength(0);
+    });
+
+    it("preserves contents when clean is false", function* () {
+      const clonesDir = path.join(testDir, "clones");
+      yield* ensureDir(clonesDir);
+      yield* writeTextFile(path.join(clonesDir, "keep.txt"), "keep");
+
+      yield* initClones(clonesDir, { clean: false });
+
+      const contents = yield* readdir(clonesDir);
+      expect(contents).toContain("keep.txt");
+    });
+  });
+});

--- a/project-repo/clones.ts
+++ b/project-repo/clones.ts
@@ -20,7 +20,7 @@ export interface CloneOptions {
  *
  * @example
  * ```ts
- * import { initClones, useClone } from "@effectionx/git";
+ * import { initClones, useClone } from "@effectionx/project-repo";
  *
  * yield* initClones("./build/clones");
  * const effectionPath = yield* useClone("thefrontside/effection");
@@ -50,7 +50,7 @@ export function* initClones(
  *
  * @example
  * ```ts
- * import { initClones, useClone } from "@effectionx/git";
+ * import { initClones, useClone } from "@effectionx/project-repo";
  *
  * yield* initClones("./build/clones");
  *
@@ -65,7 +65,7 @@ export function* useClone(nameWithOwner: string): Operation<string> {
 
   if (!(yield* exists(dirpath))) {
     yield* exec(
-      `git clone https://github.com/${nameWithOwner} ${dirpath}`,
+      `git clone https://github.com/${nameWithOwner} "${dirpath}"`,
     ).expect();
   }
 

--- a/project-repo/clones.ts
+++ b/project-repo/clones.ts
@@ -1,0 +1,73 @@
+import * as path from "node:path";
+import { emptyDir, ensureDir, exists } from "@effectionx/fs";
+import { exec } from "@effectionx/process";
+import { type Operation, createContext } from "effection";
+
+const ClonesContext = createContext<string>("git.clones");
+
+/**
+ * Options for initializing clones
+ */
+export interface CloneOptions {
+  /** Clean the directory before initializing (default: true) */
+  clean?: boolean;
+}
+
+/**
+ * Initialize the clones base directory and set the context.
+ * This should be called once at the start of your application
+ * before using `useClone`.
+ *
+ * @example
+ * ```ts
+ * import { initClones, useClone } from "@effectionx/git";
+ *
+ * yield* initClones("./build/clones");
+ * const effectionPath = yield* useClone("thefrontside/effection");
+ * ```
+ */
+export function* initClones(
+  basePath: string,
+  options: CloneOptions = {},
+): Operation<void> {
+  const { clean = true } = options;
+
+  if (clean) {
+    yield* emptyDir(basePath);
+  } else {
+    yield* ensureDir(basePath);
+  }
+
+  yield* ClonesContext.set(basePath);
+}
+
+/**
+ * Clone a GitHub repository if it doesn't already exist.
+ * The repository will be cloned to the base directory set by `initClones`.
+ *
+ * @param nameWithOwner - The repository in "owner/repo" format (e.g., "thefrontside/effection")
+ * @returns The path to the cloned repository
+ *
+ * @example
+ * ```ts
+ * import { initClones, useClone } from "@effectionx/git";
+ *
+ * yield* initClones("./build/clones");
+ *
+ * // Clone from GitHub
+ * const effectionPath = yield* useClone("thefrontside/effection");
+ * console.log(effectionPath); // "./build/clones/thefrontside/effection"
+ * ```
+ */
+export function* useClone(nameWithOwner: string): Operation<string> {
+  const basePath = yield* ClonesContext.expect();
+  const dirpath = path.resolve(basePath, nameWithOwner);
+
+  if (!(yield* exists(dirpath))) {
+    yield* exec(
+      `git clone https://github.com/${nameWithOwner} ${dirpath}`,
+    ).expect();
+  }
+
+  return dirpath;
+}

--- a/project-repo/mod.ts
+++ b/project-repo/mod.ts
@@ -1,0 +1,13 @@
+export {
+  initWorktrees,
+  useWorktree,
+  type WorktreeOptions,
+} from "./worktrees.ts";
+export { initClones, useClone, type CloneOptions } from "./clones.ts";
+export {
+  createRepo,
+  type Repo,
+  type Ref,
+  type RepoOptions,
+} from "./repo.ts";
+export { extractVersion, findLatestSemverTag } from "./semver.ts";

--- a/project-repo/package.json
+++ b/project-repo/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@effectionx/project-repo",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/mod.js",
+  "types": "./dist/mod.d.ts",
+  "exports": {
+    ".": {
+      "development": "./mod.ts",
+      "default": "./dist/mod.js"
+    }
+  },
+  "peerDependencies": {
+    "effection": "^3 || ^4"
+  },
+  "dependencies": {
+    "semver": "^7.6.3",
+    "@effectionx/fs": "workspace:*",
+    "@effectionx/process": "workspace:*"
+  },
+  "devDependencies": {
+    "@effectionx/bdd": "workspace:*"
+  },
+  "license": "MIT",
+  "author": "engineering@frontside.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thefrontside/effectionx.git"
+  },
+  "bugs": {
+    "url": "https://github.com/thefrontside/effectionx/issues"
+  },
+  "engines": {
+    "node": ">= 22"
+  },
+  "sideEffects": false
+}

--- a/project-repo/repo.test.ts
+++ b/project-repo/repo.test.ts
@@ -1,32 +1,102 @@
-import { describe, it } from "@effectionx/bdd";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, it } from "@effectionx/bdd";
+import { emptyDir, ensureDir, writeTextFile } from "@effectionx/fs";
+import { exec } from "@effectionx/process";
 import { expect } from "expect";
 
 import { createRepo } from "./mod.ts";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const testDir = path.join(__dirname, "test-tmp", "repo-test");
+
 describe("repo", () => {
   describe("createRepo", () => {
+    const repoDir = path.join(testDir, "repo");
+
+    beforeAll(function* () {
+      // Create a self-contained test git repository with tags
+      yield* emptyDir(testDir);
+      yield* ensureDir(repoDir);
+      yield* exec("git init", { cwd: repoDir }).expect();
+      yield* exec("git config user.email 'test@test.com'", {
+        cwd: repoDir,
+      }).expect();
+      yield* exec("git config user.name 'Test'", { cwd: repoDir }).expect();
+
+      // Create first commit and tag (lightweight tag - no editor)
+      yield* writeTextFile(path.join(repoDir, "file.txt"), "v1");
+      yield* exec("git add .", { cwd: repoDir }).expect();
+      yield* exec("git commit -m 'v1'", { cwd: repoDir }).expect();
+      yield* exec("git tag -a v1.0.0 -m 'v1.0.0'", { cwd: repoDir }).expect();
+
+      // Create second commit and tag
+      yield* writeTextFile(path.join(repoDir, "file.txt"), "v2");
+      yield* exec("git add .", { cwd: repoDir }).expect();
+      yield* exec("git commit -m 'v2'", { cwd: repoDir }).expect();
+      yield* exec("git tag -a v2.0.0 -m 'v2.0.0'", { cwd: repoDir }).expect();
+
+      // Create a prerelease tag
+      yield* writeTextFile(path.join(repoDir, "file.txt"), "v3-beta");
+      yield* exec("git add .", { cwd: repoDir }).expect();
+      yield* exec("git commit -m 'v3-beta'", { cwd: repoDir }).expect();
+      yield* exec("git tag -a v3.0.0-beta.1 -m 'v3.0.0-beta.1'", {
+        cwd: repoDir,
+      }).expect();
+    });
+
     it("lists tags matching a pattern", function* () {
-      const repo = createRepo({ owner: "thefrontside", name: "effectionx" });
+      const repo = createRepo({ owner: "test", name: "repo", cwd: repoDir });
 
-      // This repo has tags like @effection/process-v2.0.0-beta.0
-      const tags = yield* repo.tags(/^@effection\/process-v/);
+      const tags = yield* repo.tags(/^v/);
 
-      expect(tags.length).toBeGreaterThan(0);
-      expect(tags[0].name).toMatch(/^@effection\/process-v/);
-      expect(tags[0].nameWithOwner).toBe("thefrontside/effectionx");
-      expect(tags[0].url).toContain("github.com/thefrontside/effectionx/tree/");
+      expect(tags.length).toBe(3);
+      expect(tags.map((t) => t.name)).toContain("v1.0.0");
+      expect(tags.map((t) => t.name)).toContain("v2.0.0");
+      expect(tags.map((t) => t.name)).toContain("v3.0.0-beta.1");
+    });
+
+    it("filters tags by pattern", function* () {
+      const repo = createRepo({ owner: "test", name: "repo", cwd: repoDir });
+
+      const tags = yield* repo.tags(/^v[12]\./);
+
+      expect(tags.length).toBe(2);
+      expect(tags.map((t) => t.name)).toContain("v1.0.0");
+      expect(tags.map((t) => t.name)).toContain("v2.0.0");
+    });
+
+    it("returns correct ref structure", function* () {
+      const repo = createRepo({ owner: "test", name: "repo", cwd: repoDir });
+
+      const tags = yield* repo.tags(/^v1\./);
+
+      expect(tags.length).toBe(1);
+      expect(tags[0].name).toBe("v1.0.0");
+      expect(tags[0].nameWithOwner).toBe("test/repo");
+      expect(tags[0].url).toBe("https://github.com/test/repo/tree/v1.0.0");
     });
 
     it("finds the latest tag matching a pattern", function* () {
-      const repo = createRepo({ owner: "thefrontside", name: "effectionx" });
+      const repo = createRepo({ owner: "test", name: "repo", cwd: repoDir });
 
-      const latest = yield* repo.latest(/^@effection\/process-v/);
+      const latest = yield* repo.latest(/^v/);
 
-      expect(latest.name).toMatch(/^@effection\/process-v/);
+      // v3.0.0-beta.1 is latest because 3 > 2 > 1
+      expect(latest.name).toBe("v3.0.0-beta.1");
+    });
+
+    it("finds latest stable version when excluding prereleases", function* () {
+      const repo = createRepo({ owner: "test", name: "repo", cwd: repoDir });
+
+      // Only match stable versions (no hyphen after version)
+      const latest = yield* repo.latest(/^v\d+\.\d+\.\d+$/);
+
+      expect(latest.name).toBe("v2.0.0");
     });
 
     it("throws when no tags match", function* () {
-      const repo = createRepo({ owner: "thefrontside", name: "effectionx" });
+      const repo = createRepo({ owner: "test", name: "repo", cwd: repoDir });
 
       let error: Error | undefined;
       try {

--- a/project-repo/repo.test.ts
+++ b/project-repo/repo.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "@effectionx/bdd";
+import { expect } from "expect";
+
+import { createRepo } from "./mod.ts";
+
+describe("repo", () => {
+  describe("createRepo", () => {
+    it("lists tags matching a pattern", function* () {
+      const repo = createRepo({ owner: "thefrontside", name: "effectionx" });
+
+      // This repo has tags like @effection/process-v2.0.0-beta.0
+      const tags = yield* repo.tags(/^@effection\/process-v/);
+
+      expect(tags.length).toBeGreaterThan(0);
+      expect(tags[0].name).toMatch(/^@effection\/process-v/);
+      expect(tags[0].nameWithOwner).toBe("thefrontside/effectionx");
+      expect(tags[0].url).toContain("github.com/thefrontside/effectionx/tree/");
+    });
+
+    it("finds the latest tag matching a pattern", function* () {
+      const repo = createRepo({ owner: "thefrontside", name: "effectionx" });
+
+      const latest = yield* repo.latest(/^@effection\/process-v/);
+
+      expect(latest.name).toMatch(/^@effection\/process-v/);
+    });
+
+    it("throws when no tags match", function* () {
+      const repo = createRepo({ owner: "thefrontside", name: "effectionx" });
+
+      let error: Error | undefined;
+      try {
+        yield* repo.latest(/^nonexistent-pattern-/);
+      } catch (e) {
+        error = e as Error;
+      }
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("Could not retrieve latest tag");
+    });
+  });
+});

--- a/project-repo/repo.ts
+++ b/project-repo/repo.ts
@@ -1,0 +1,109 @@
+import { exec } from "@effectionx/process";
+import type { Operation } from "effection";
+import { findLatestSemverTag } from "./semver.ts";
+
+/**
+ * Represents a git reference (tag, branch, or commit)
+ */
+export interface Ref {
+  /** The ref name (e.g., "v3.0.0", "main") */
+  name: string;
+  /** The full repository identifier in "owner/repo" format */
+  nameWithOwner: string;
+  /** URL to view this ref on GitHub */
+  url: string;
+}
+
+/**
+ * Options for creating a repository abstraction
+ */
+export interface RepoOptions {
+  /** Repository name */
+  name: string;
+  /** Repository owner (organization or user) */
+  owner: string;
+}
+
+/**
+ * Repository abstraction for working with git tags
+ */
+export interface Repo {
+  /** Repository name */
+  name: string;
+  /** Repository owner */
+  owner: string;
+  /**
+   * Get all tags matching a pattern
+   *
+   * @example
+   * ```ts
+   * const tags = yield* repo.tags(/^v4\./);
+   * ```
+   */
+  tags(matching: RegExp): Operation<Ref[]>;
+  /**
+   * Get the latest semver tag matching a pattern
+   *
+   * @example
+   * ```ts
+   * const latest = yield* repo.latest(/^v4\./);
+   * console.log(latest.name); // "v4.2.1"
+   * ```
+   */
+  latest(matching: RegExp): Operation<Ref>;
+}
+
+/**
+ * Create a repository abstraction for working with git tags.
+ * This assumes you're running commands from within the repository.
+ *
+ * @example
+ * ```ts
+ * import { createRepo } from "@effectionx/git";
+ *
+ * const repo = createRepo({ owner: "thefrontside", name: "effection" });
+ *
+ * // Get all v4.x tags
+ * const v4Tags = yield* repo.tags(/^v4\./);
+ *
+ * // Get the latest v4.x tag
+ * const latest = yield* repo.latest(/^v4\./);
+ * console.log(latest.name); // "v4.2.1"
+ * console.log(latest.url);  // "https://github.com/thefrontside/effection/tree/v4.2.1"
+ * ```
+ */
+export function createRepo(options: RepoOptions): Repo {
+  const { name, owner } = options;
+
+  const repo: Repo = {
+    name,
+    owner,
+
+    *tags(matching: RegExp): Operation<Ref[]> {
+      const result = yield* exec("git tag").expect();
+      const names = result.stdout
+        .trim()
+        .split(/\s+/)
+        .filter((tag: string) => matching.test(tag));
+
+      return names.map((tagname: string) => ({
+        name: tagname,
+        nameWithOwner: `${owner}/${name}`,
+        url: `https://github.com/${owner}/${name}/tree/${tagname}`,
+      }));
+    },
+
+    *latest(matching) {
+      const tags = yield* repo.tags(matching);
+      const latest = findLatestSemverTag(tags);
+
+      if (!latest) {
+        throw new Error(`Could not retrieve latest tag matching ${matching}`);
+      }
+
+      return latest;
+    },
+  };
+
+  return repo;
+}

--- a/project-repo/semver.test.ts
+++ b/project-repo/semver.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "@effectionx/bdd";
+import { expect } from "expect";
+
+import { extractVersion, findLatestSemverTag } from "./mod.ts";
+
+describe("semver", () => {
+  describe("extractVersion", () => {
+    it("extracts version from tag with v prefix", function* () {
+      expect(extractVersion("v3.2.1")).toBe("3.2.1");
+    });
+
+    it("extracts version from plain semver", function* () {
+      expect(extractVersion("3.2.1")).toBe("3.2.1");
+    });
+
+    it("extracts version with prerelease", function* () {
+      expect(extractVersion("v1.0.0-beta.1")).toBe("1.0.0-beta.1");
+    });
+
+    it("extracts version with build metadata", function* () {
+      expect(extractVersion("1.0.0+build.123")).toBe("1.0.0+build.123");
+    });
+
+    it("extracts version from complex tag name", function* () {
+      expect(extractVersion("release-2.0.0-alpha")).toBe("2.0.0-alpha");
+    });
+
+    it("returns 0.0.0 for non-semver strings", function* () {
+      expect(extractVersion("not-a-version")).toBe("0.0.0");
+      expect(extractVersion("latest")).toBe("0.0.0");
+    });
+  });
+
+  describe("findLatestSemverTag", () => {
+    it("finds the latest tag from a list", function* () {
+      const tags = [{ name: "v1.0.0" }, { name: "v2.0.0" }, { name: "v1.5.0" }];
+
+      const latest = findLatestSemverTag(tags);
+      expect(latest?.name).toBe("v2.0.0");
+    });
+
+    it("handles prerelease versions correctly", function* () {
+      const tags = [
+        { name: "v1.0.0" },
+        { name: "v2.0.0-beta.1" },
+        { name: "v1.5.0" },
+      ];
+
+      // 2.0.0-beta.1 > 1.5.0 because 2 > 1
+      const latest = findLatestSemverTag(tags);
+      expect(latest?.name).toBe("v2.0.0-beta.1");
+    });
+
+    it("returns undefined for empty array", function* () {
+      const latest = findLatestSemverTag([]);
+      expect(latest).toBeUndefined();
+    });
+
+    it("works with complex tag names", function* () {
+      const tags = [
+        { name: "effection-v3.0.0" },
+        { name: "effection-v4.1.0" },
+        { name: "effection-v4.0.0" },
+      ];
+
+      const latest = findLatestSemverTag(tags);
+      expect(latest?.name).toBe("effection-v4.1.0");
+    });
+  });
+});

--- a/project-repo/semver.ts
+++ b/project-repo/semver.ts
@@ -1,0 +1,55 @@
+import { rsort } from "semver";
+
+/**
+ * Extract a semver version string from an input string (e.g., tag name).
+ * Returns "0.0.0" if no valid semver is found.
+ *
+ * @example
+ * ```ts
+ * import { extractVersion } from "@effectionx/git";
+ *
+ * extractVersion("v3.2.1");     // "3.2.1"
+ * extractVersion("release-1.0.0-beta.1"); // "1.0.0-beta.1"
+ * extractVersion("not-a-version"); // "0.0.0"
+ * ```
+ */
+export function extractVersion(input: string): string {
+  // Regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+  const parts = input.match(
+    /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/,
+  );
+  if (parts) {
+    return parts[0];
+  }
+  return "0.0.0";
+}
+
+/**
+ * Find the latest semver tag from an array of tags.
+ *
+ * @example
+ * ```ts
+ * import { findLatestSemverTag } from "@effectionx/git";
+ *
+ * const tags = [
+ *   { name: "v1.0.0" },
+ *   { name: "v2.0.0" },
+ *   { name: "v1.5.0" },
+ * ];
+ *
+ * const latest = findLatestSemverTag(tags);
+ * console.log(latest?.name); // "v2.0.0"
+ * ```
+ */
+export function findLatestSemverTag<T extends { name: string }>(
+  tags: T[],
+): T | undefined {
+  if (tags.length === 0) {
+    return undefined;
+  }
+
+  const versions = tags.map((tag) => extractVersion(tag.name));
+  const [latest] = rsort(versions);
+
+  return tags.find((tag) => tag.name.endsWith(latest));
+}

--- a/project-repo/tsconfig.json
+++ b/project-repo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.test.ts", "dist"],
+  "references": [
+    {
+      "path": "../bdd"
+    },
+    {
+      "path": "../process"
+    },
+    {
+      "path": "../fs"
+    }
+  ]
+}

--- a/project-repo/worktrees.test.ts
+++ b/project-repo/worktrees.test.ts
@@ -1,0 +1,76 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, it } from "@effectionx/bdd";
+import {
+  emptyDir,
+  ensureDir,
+  exists,
+  readdir,
+  writeTextFile,
+} from "@effectionx/fs";
+import { expect } from "expect";
+
+import { initWorktrees, useWorktree } from "./mod.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const testDir = path.join(__dirname, "test-tmp", "worktrees-test");
+
+describe("worktrees", () => {
+  beforeEach(function* () {
+    yield* emptyDir(testDir);
+  });
+
+  describe("initWorktrees", () => {
+    it("creates the worktrees directory", function* () {
+      const worktreesDir = path.join(testDir, "worktrees");
+
+      yield* initWorktrees(worktreesDir);
+
+      expect(yield* exists(worktreesDir)).toBe(true);
+    });
+
+    it("cleans the directory by default", function* () {
+      const worktreesDir = path.join(testDir, "worktrees");
+      yield* ensureDir(worktreesDir);
+      yield* writeTextFile(path.join(worktreesDir, "old.txt"), "old");
+
+      yield* initWorktrees(worktreesDir);
+
+      const contents = yield* readdir(worktreesDir);
+      expect(contents).toHaveLength(0);
+    });
+
+    it("preserves contents when clean is false", function* () {
+      const worktreesDir = path.join(testDir, "worktrees");
+      yield* ensureDir(worktreesDir);
+      yield* writeTextFile(path.join(worktreesDir, "keep.txt"), "keep");
+
+      yield* initWorktrees(worktreesDir, { clean: false });
+
+      const contents = yield* readdir(worktreesDir);
+      expect(contents).toContain("keep.txt");
+    });
+  });
+
+  describe("useWorktree", () => {
+    it("creates a worktree for a branch", function* () {
+      const worktreesDir = path.join(testDir, "worktrees");
+      yield* initWorktrees(worktreesDir);
+
+      const worktreePath = yield* useWorktree("main");
+
+      expect(yield* exists(worktreePath)).toBe(true);
+      expect(yield* exists(path.join(worktreePath, "package.json"))).toBe(true);
+    });
+
+    it("reuses existing worktree", function* () {
+      const worktreesDir = path.join(testDir, "worktrees");
+      yield* initWorktrees(worktreesDir);
+
+      const path1 = yield* useWorktree("main");
+      const path2 = yield* useWorktree("main");
+
+      expect(path1).toBe(path2);
+    });
+  });
+});

--- a/project-repo/worktrees.test.ts
+++ b/project-repo/worktrees.test.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { beforeEach, describe, it } from "@effectionx/bdd";
+import { beforeAll, beforeEach, describe, it } from "@effectionx/bdd";
 import {
   emptyDir,
   ensureDir,
@@ -8,6 +8,7 @@ import {
   readdir,
   writeTextFile,
 } from "@effectionx/fs";
+import { exec } from "@effectionx/process";
 import { expect } from "expect";
 
 import { initWorktrees, useWorktree } from "./mod.ts";
@@ -16,11 +17,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const testDir = path.join(__dirname, "test-tmp", "worktrees-test");
 
 describe("worktrees", () => {
-  beforeEach(function* () {
-    yield* emptyDir(testDir);
-  });
-
   describe("initWorktrees", () => {
+    beforeEach(function* () {
+      yield* emptyDir(testDir);
+    });
+
     it("creates the worktrees directory", function* () {
       const worktreesDir = path.join(testDir, "worktrees");
 
@@ -53,22 +54,45 @@ describe("worktrees", () => {
   });
 
   describe("useWorktree", () => {
-    it("creates a worktree for a branch", function* () {
-      const worktreesDir = path.join(testDir, "worktrees");
-      yield* initWorktrees(worktreesDir);
+    const repoDir = path.join(testDir, "repo");
+    const worktreesDir = path.join(testDir, "worktrees");
 
-      const worktreePath = yield* useWorktree("main");
+    beforeAll(function* () {
+      // Create a self-contained test git repository
+      yield* emptyDir(testDir);
+      yield* ensureDir(repoDir);
+      yield* exec("git init", { cwd: repoDir }).expect();
+      yield* exec("git config user.email 'test@test.com'", {
+        cwd: repoDir,
+      }).expect();
+      yield* exec("git config user.name 'Test'", { cwd: repoDir }).expect();
+      yield* writeTextFile(path.join(repoDir, "file.txt"), "content");
+      yield* exec("git add .", { cwd: repoDir }).expect();
+      yield* exec("git commit -m 'initial'", { cwd: repoDir }).expect();
+      yield* exec("git branch test-branch", { cwd: repoDir }).expect();
+    });
+
+    beforeEach(function* () {
+      // Clean worktrees directory between tests
+      yield* emptyDir(worktreesDir);
+      // Prune any stale worktree references
+      yield* exec("git worktree prune", { cwd: repoDir }).expect();
+    });
+
+    it("creates a worktree for a branch", function* () {
+      yield* initWorktrees(worktreesDir, { cwd: repoDir });
+
+      const worktreePath = yield* useWorktree("test-branch");
 
       expect(yield* exists(worktreePath)).toBe(true);
-      expect(yield* exists(path.join(worktreePath, "package.json"))).toBe(true);
+      expect(yield* exists(path.join(worktreePath, "file.txt"))).toBe(true);
     });
 
     it("reuses existing worktree", function* () {
-      const worktreesDir = path.join(testDir, "worktrees");
-      yield* initWorktrees(worktreesDir);
+      yield* initWorktrees(worktreesDir, { cwd: repoDir });
 
-      const path1 = yield* useWorktree("main");
-      const path2 = yield* useWorktree("main");
+      const path1 = yield* useWorktree("test-branch");
+      const path2 = yield* useWorktree("test-branch");
 
       expect(path1).toBe(path2);
     });

--- a/project-repo/worktrees.ts
+++ b/project-repo/worktrees.ts
@@ -1,0 +1,70 @@
+import * as path from "node:path";
+import { emptyDir, ensureDir, exists } from "@effectionx/fs";
+import { exec } from "@effectionx/process";
+import { type Operation, createContext } from "effection";
+
+const WorktreesContext = createContext<string>("git.worktrees");
+
+/**
+ * Options for initializing worktrees
+ */
+export interface WorktreeOptions {
+  /** Clean the directory before initializing (default: true) */
+  clean?: boolean;
+}
+
+/**
+ * Initialize the worktrees base directory and set the context.
+ * This should be called once at the start of your application
+ * before using `useWorktree`.
+ *
+ * @example
+ * ```ts
+ * import { initWorktrees, useWorktree } from "@effectionx/git";
+ *
+ * yield* initWorktrees("./build/worktrees");
+ * const v3Path = yield* useWorktree("v3.0.0");
+ * ```
+ */
+export function* initWorktrees(
+  basePath: string,
+  options: WorktreeOptions = {},
+): Operation<void> {
+  const { clean = true } = options;
+
+  if (clean) {
+    yield* emptyDir(basePath);
+  } else {
+    yield* ensureDir(basePath);
+  }
+
+  yield* WorktreesContext.set(basePath);
+}
+
+/**
+ * Get or create a git worktree for the specified ref (branch, tag, or commit).
+ * The worktree will be created in the base directory set by `initWorktrees`.
+ *
+ * @example
+ * ```ts
+ * import { initWorktrees, useWorktree } from "@effectionx/git";
+ *
+ * yield* initWorktrees("./build/worktrees");
+ *
+ * // Create worktree for a tag
+ * const v3Path = yield* useWorktree("v3.0.0");
+ *
+ * // Create worktree for a branch
+ * const mainPath = yield* useWorktree("main");
+ * ```
+ */
+export function* useWorktree(refname: string): Operation<string> {
+  const basePath = yield* WorktreesContext.expect();
+  const checkout = path.resolve(basePath, refname);
+
+  if (!(yield* exists(checkout))) {
+    yield* exec(`git worktree add --force ${checkout} ${refname}`).expect();
+  }
+
+  return checkout;
+}

--- a/project-repo/worktrees.ts
+++ b/project-repo/worktrees.ts
@@ -78,7 +78,7 @@ export function* useWorktree(refname: string): Operation<string> {
   const checkout = path.resolve(basePath, refname);
 
   if (!(yield* exists(checkout))) {
-    yield* exec(`git worktree add --force ${checkout} ${refname}`, {
+    yield* exec(`git worktree add --force "${checkout}" ${refname}`, {
       cwd,
     }).expect();
   }


### PR DESCRIPTION
# Motivation

The effection www codebase contains useful utilities for managing git worktrees, clones, and repository tags that would be valuable as a reusable package. This extracts those utilities into `@effectionx/project-repo` for use in documentation sites, build tools, and other projects that need to work with multiple repository versions.

# Approach

Created a new `@effectionx/project-repo` package with the following features:

- **Worktrees**: `initWorktrees()` and `useWorktree()` for managing git worktrees to check out multiple refs simultaneously
- **Clones**: `initClones()` and `useClone()` for cloning and caching GitHub repositories
- **Repository**: `createRepo()` abstraction for querying git tags with regex patterns and finding latest semver versions
- **Semver**: `extractVersion()` and `findLatestSemverTag()` utilities for working with version strings

The package depends on `@effectionx/process` for shell execution and `@effectionx/fs` for filesystem operations. All operations are Effection generators with proper structured concurrency.

Tests cover all functionality including real git worktree creation and tag listing against the effectionx repository itself.