### PR TITLE
✨ reduce() helper

### DIFF
--- a/stream-helpers/README.md
+++ b/stream-helpers/README.md
@@ -63,6 +63,27 @@ function* example(stream: Stream<number, unknown>) {
 }
 ```
 
+### Reduce
+
+The `reduce` helper transforms each item in a stream by applying it to
+an accumulated value.
+
+```typescript
+import { reduce } from "@effectionx/stream-helpers";
+import { each } from "effection";
+
+function* example(stream: Stream<number, unknown>) {
+  let sum = reduce(function* (total: number, current: number) {
+    return total + current;
+  }, 0);
+
+  for (let value of yield* each(sum(streamOf([1,2,3]))) {
+    console.log(value) // logs 1 -> 3 -> 6
+    yield* each.next();
+  }
+}
+```
+
 ### Batch
 
 The `batch` helper is useful when you want to convert individual items passing

--- a/stream-helpers/mod.ts
+++ b/stream-helpers/mod.ts
@@ -6,3 +6,5 @@ export * from "./tracker.ts";
 export * from "./for-each.ts";
 export * from "./subject.ts";
 export * from "./lines.ts";
+export * from "./stream-of.ts";
+export * from "./reduce.ts";

--- a/stream-helpers/package.json
+++ b/stream-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectionx/stream-helpers",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",

--- a/stream-helpers/reduce.test.ts
+++ b/stream-helpers/reduce.test.ts
@@ -1,0 +1,67 @@
+import { createChannel, type Operation, sleep, spawn } from "effection";
+import { describe, it } from "@effectionx/bdd";
+import { expect } from "expect";
+
+import { forEach } from "./for-each.ts";
+import { reduce } from "./reduce.ts";
+import { streamOf } from "./stream-of.ts";
+
+describe("reduce", () => {
+  it("accumulates its value from the initial", function* () {
+    expect.assertions(1);
+
+    let stream = streamOf([1, 2, 3]);
+
+    let sum = reduce(function* (total, current: number): Operation<number> {
+      return total + current;
+    }, 0);
+
+    let sequence: number[] = [];
+    yield* forEach(function* (item) {
+      sequence.push(item);
+    }, sum(stream));
+
+    expect(sequence).toEqual([1, 3, 6]);
+  });
+
+  it("does not interfere with the closing value", function* () {
+    expect.assertions(1);
+    let stream = streamOf(
+      (function* () {
+        yield { hello: "world" } as Record<string, string>;
+        yield { goobye: "world" };
+        return 42;
+      })(),
+    );
+
+    let merge = reduce(
+      function* (
+        total,
+        current: Record<string, string>,
+      ): Operation<Record<string, string>> {
+        return { ...total, ...current };
+      },
+      {} as Record<string, string>,
+    );
+
+    const closeValue = yield* forEach(function* () {}, merge(stream));
+    expect(closeValue).toBe(42);
+  });
+
+  it("does not emit items when the reduced value has changed", function* () {
+    expect.assertions(1);
+
+    let stream = streamOf([1, 0, 2]);
+
+    let sum = reduce(function* (total, current: number): Operation<number> {
+      return total + current;
+    }, 0);
+
+    let sequence: number[] = [];
+    yield* forEach(function* (item) {
+      sequence.push(item);
+    }, sum(stream));
+
+    expect(sequence).toEqual([1, 3]);
+  });
+});

--- a/stream-helpers/reduce.ts
+++ b/stream-helpers/reduce.ts
@@ -1,0 +1,49 @@
+import type { Operation, Stream } from "effection";
+
+/**
+ * Transforms a stream by taking each item and applying it to an
+ * accumulated value to produce a new accumulated value which is then
+ *  passed downstream.
+ *
+ * @example
+ * ```ts
+ * import { reduce, streamOf } from "@effectionx/stream-helpers";
+ *
+ * const sum = reduce(function*(total: number, item: number) {
+ *   return sum + number;
+ * }, 0);
+ *
+ * sum(streamOf([1,2,3])) //=> yields 1, 3, 6
+ * ```
+ *
+ * @param fn - The operation to apply a single item to the accumulated value
+ * @param initial - The first accumulated value from which all others will descend
+ * @returns A stream transformer that applies the reduction over the lifetime of the stream
+ */
+export function reduce<T, TSum>(
+  fn: (current: TSum, item: T) => Operation<TSum>,
+  initial: TSum,
+): <TClose>(stream: Stream<T, TClose>) => Stream<TSum, TClose> {
+  return (upstream) => ({
+    *[Symbol.iterator]() {
+      let current = initial;
+      let subscription = yield* upstream;
+
+      return {
+        *next() {
+          let next = yield* subscription.next();
+          while (!next.done) {
+            let reduction = yield* fn(current, next.value);
+            if (reduction !== current) {
+              current = reduction;
+              return { done: false, value: current } as const;
+            }
+
+            next = yield* subscription.next();
+          }
+          return next;
+        },
+      };
+    },
+  });
+}

--- a/stream-helpers/stream-of.ts
+++ b/stream-helpers/stream-of.ts
@@ -1,0 +1,22 @@
+import type { Stream } from "effection";
+
+/**
+ * Lift a synchronous iterable into a stream context.
+ *
+ * @param iterable - synchronous iterable to present as an Effection `Stream`
+ * @returns a stream that yields the members of the iterable.
+ */
+export function streamOf<T, TDone>(
+  iterable: Iterable<T, TDone>,
+): Stream<T, TDone> {
+  return {
+    *[Symbol.iterator]() {
+      let iterator = iterable[Symbol.iterator]();
+      return {
+        *next() {
+          return iterator.next();
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
# Motivation

Stream reduction, the application of sequence of values to an accumulated value is very helpful in the maintenance of state over time.

# Approach
In addition to the `reduce()` helper, this adds a `streamOf()` helper to "lift" simple iterables into a `Stream` context.