### PR TITLE
Update preview package publish command to use pnpm

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -36,4 +36,4 @@ jobs:
           for workspace in ${{ steps.changed.outputs.workspaces }}; do
             dirs="$dirs ./$workspace"
           done
-          npx pkg-pr-new publish $dirs
+          npx pkg-pr-new publish --pnpm $dirs


### PR DESCRIPTION
# Motivation

Preview packages with the workspace dependency were not properly handled. Using this option will tell the preview package to convert the versions and use a preview version as appropriate.

For example, in the inspector package, we changed both the inspector and stream-helpers. The stream-helpers was coming in as `workspace:*`. With this change, inspector correctly specifies a preview version of stream-helpers as it's dependency.
