### PR TITLE
Enable sticky comment for Claude reviews

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: true
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 


### PR DESCRIPTION
# Motivation

Currently Claude creates a new comment every time the PR is updated (on `synchronize` events). This clutters the PR timeline with multiple review comments.

# Approach

Enable `use_sticky_comment: true` in the Claude Code Action workflow. This makes Claude update the same comment instead of creating new ones on each push.

From the [docs](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md):
> `use_sticky_comment` - Use just one comment to deliver PR comments (only applies for pull_request event workflows)