### PR TITLE
Fix sticky comment for Claude reviews

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -28,9 +28,10 @@ jobs:
             Follow the instructions in `.agents/policy-officer.md` to review this PR
             for compliance with the policies in `.policies/index.md`.
 
-            Use `gh pr diff` to see changes, `gh pr comment` for feedback,
-            and inline comments for specific code issues.
+            Use `gh pr diff` to see changes. Output your review as text - it will
+            be posted as a comment automatically. Use inline comments for specific
+            code issues.
 
           claude_args: |
-            --allowedTools "Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Read,Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
             --max-turns 15


### PR DESCRIPTION
# Motivation

Claude is posting a new comment on every push instead of updating a single sticky comment. This clutters the PR timeline.

# Approach

The `use_sticky_comment: true` option only works when Claude outputs text directly - not when it uses `gh pr comment` to post comments manually.

**Fix:** Remove `gh pr comment` from the allowed tools. Now Claude will output its review as text, which the action automatically posts as a sticky comment that gets updated on subsequent pushes.

## Before
- Claude used `gh pr comment` to post reviews
- Each push created a new comment
- 12+ comments per PR

## After
- Claude outputs review as text
- Action posts it as a sticky comment
- Single comment updated on each push