### PR TITLE
🙈 Add .agent-shell to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ dist/
 # pnpm config (created by test-matrix runner)
 .npmrc
 
+# Agent shell directories
+.agent-shell/
+


### PR DESCRIPTION
# Motivation

`agent-shell` is a new Emacs integration for multiple AI backends. It stores all its configuration and chat histories in the `.agent-shell/` directory.

## Approach

Ignore it!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to exclude additional build directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->