### PR TITLE
🔧 Disable annoying linting rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,10 @@
       "recommended": true,
       "style": {
         "noParameterAssign": "off",
-        "useConst": "off"
+        "useConst": "off",
+        "noNonNullAssertion": "off",
+        "noUselessElse": "off",
+        "noUnusedTemplateLiteral": "off"
       },
       "correctness": {
         "useYield": "off"

--- a/signals/array.ts
+++ b/signals/array.ts
@@ -77,7 +77,6 @@ export function createArraySignal<T>(
       },
       *shift() {
         yield* is(array, (array) => array.length > 0);
-        // biome-ignore lint/style/noNonNullAssertion: is() ensures array.length > 0
         const value = ref.current.first()!;
         ref.current = ref.current.shift();
         signal.send(ref.current.toArray());

--- a/stream-helpers/batch.ts
+++ b/stream-helpers/batch.ts
@@ -41,7 +41,6 @@ export function batch(
             value: undefined as never,
           };
           if (lastPull && options.maxTime) {
-            // biome-ignore lint/style/noNonNullAssertion: lastPull checked above
             const timeout = yield* timebox(options.maxTime, () => lastPull!);
             if (timeout.timeout) {
               yield* lastPull.halt();

--- a/stream-helpers/subject.ts
+++ b/stream-helpers/subject.ts
@@ -48,7 +48,6 @@ export function createSubject<T>(): <TClose>(
         ? {
             *next() {
               iterator = upstream;
-              // biome-ignore lint/style/noNonNullAssertion: current checked in ternary condition
               return current!;
             },
           }

--- a/task-buffer/task-buffer.ts
+++ b/task-buffer/task-buffer.ts
@@ -74,7 +74,6 @@ export function useTaskBuffer(max: number): Operation<TaskBuffer> {
         if (requests.length === 0) {
           yield* next(input);
         } else if (buffer.size < max) {
-          // biome-ignore lint/style/noNonNullAssertion: requests.length > 0 from else branch
           const request = requests.pop()!;
           let task = yield* scope.spawn(request.operation);
           buffer.add(task);


### PR DESCRIPTION
## Motivation

Biome setttings are a bit too restrictive. Specifically, I think that explicit "else" branches are better since they are dumber, and they keep you honest. Also, we're adults and we don't use non null assertions unless we have a type guard.

## Approach
Disable those rules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated linter configuration to disable additional style validation checks.

* **Chores**
  * Removed lint suppression comments throughout the codebase for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->