### PR TITLE
chore: add strict policy enforcement to CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,9 +19,23 @@ reviews:
 
     - path: "**/package.json"
       instructions: |
-        Review for compliance with `.policies/version-bump.md`:
+        Review for compliance with policies in `.policies/index.md`:
+        - `.policies/package-json-metadata.md` (Strict): every published package must include a non-empty `description` field
+        - Description policy requirements: single sentence, under 120 chars, no Markdown, no trailing period
+        - Strict policy violations must be treated as blocking
+        - `.policies/version-bump.md`:
         - If source files in this package changed, version must be bumped
         - Major for breaking changes, minor for features, patch for fixes
+
+  pre_merge_checks:
+    custom_checks:
+      - mode: error
+        name: Policy Compliance
+        instructions: |
+          Enforce policy compliance using `.policies/index.md` as the single source of truth.
+          - Strict and Recommended policy violations must fail this check.
+          - For `**/package.json`, enforce `.policies/package-json-metadata.md` (non-empty `description` with required format).
+          - For package source changes, enforce `.policies/version-bump.md`.
 
   tools:
     biome:


### PR DESCRIPTION
# Motivation

The CodeRabbit configuration was missing enforcement of the strict `package-json-metadata.md` policy that was added in PR #151. This left a gap where PRs could pass CodeRabbit review without proper `description` fields in package.json files.

# Approach

- Updated `**/package.json` path instructions to reference `.policies/index.md` as the source of truth
- Added explicit enforcement of `.policies/package-json-metadata.md` (strict policy requiring description field)
- Added `pre_merge_checks.custom_checks` section with a "Policy Compliance" check that fails PRs violating strict or recommended policies
- Description policy requirements are now explicit: single sentence, under 120 chars, no Markdown, no trailing period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review policies with stricter enforcement for package metadata, requiring single-sentence descriptions under 120 characters without Markdown formatting.
  * Introduced automatic policy compliance checks that will block PRs containing strict or recommended policy violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->