### PR TITLE
feat(fetch): add fetchApi with middleware support

### DIFF
--- a/fetch/api.ts
+++ b/fetch/api.ts
@@ -4,7 +4,7 @@ import { type Operation, until, useAbortSignal } from "effection";
 import { createFetchResponse } from "./create-fetch-response.ts";
 import { type FetchInit, type FetchResponse, HttpError } from "./fetch.ts";
 
-export interface FetchHandler {
+export interface Fetch {
   fetch(
     input: RequestInfo | URL,
     init: FetchInit | undefined,
@@ -12,7 +12,7 @@ export interface FetchHandler {
   ): Operation<FetchResponse>;
 }
 
-export const FetchApi: Api<FetchHandler> = createApi("fetch", {
+export const FetchApi: Api<Fetch> = createApi("fetch", {
   *fetch(
     input: RequestInfo | URL,
     init: FetchInit | undefined,

--- a/fetch/api.ts
+++ b/fetch/api.ts
@@ -1,0 +1,38 @@
+import { type Api, createApi } from "@effectionx/context-api";
+import { type Operation, until, useAbortSignal } from "effection";
+
+import { createFetchResponse } from "./create-fetch-response.ts";
+import { type FetchInit, type FetchResponse, HttpError } from "./fetch.ts";
+
+export interface FetchHandler {
+  fetch(
+    input: RequestInfo | URL,
+    init: FetchInit | undefined,
+    shouldExpect: boolean,
+  ): Operation<FetchResponse>;
+}
+
+export const FetchApi: Api<FetchHandler> = createApi("fetch", {
+  *fetch(
+    input: RequestInfo | URL,
+    init: FetchInit | undefined,
+    shouldExpect: boolean,
+  ): Operation<FetchResponse> {
+    let signal = yield* useAbortSignal();
+    let response = yield* until(globalThis.fetch(input, { ...init, signal }));
+    let fetchResponse = createFetchResponse(response);
+
+    if (shouldExpect && !response.ok) {
+      throw new HttpError(
+        response.status,
+        response.statusText,
+        response.url,
+        fetchResponse,
+      );
+    }
+
+    return fetchResponse;
+  },
+});
+
+export const coreFetch = FetchApi.operations.fetch;

--- a/fetch/create-fetch-response.ts
+++ b/fetch/create-fetch-response.ts
@@ -1,0 +1,73 @@
+import { stream, type Operation, type Stream, until } from "effection";
+
+import { type FetchResponse, HttpError } from "./fetch.ts";
+
+export function createFetchResponse(response: Response): FetchResponse {
+  let self: FetchResponse = {
+    get ok() {
+      return response.ok;
+    },
+    get status() {
+      return response.status;
+    },
+    get statusText() {
+      return response.statusText;
+    },
+    get headers() {
+      return response.headers;
+    },
+    get url() {
+      return response.url;
+    },
+    get redirected() {
+      return response.redirected;
+    },
+    get type() {
+      return response.type;
+    },
+    get bodyUsed() {
+      return response.bodyUsed;
+    },
+    get raw() {
+      return response;
+    },
+    *json<T = unknown>(parse?: (value: unknown) => T): Operation<T> {
+      let value: unknown = yield* until(response.json());
+      return parse ? parse(value) : (value as T);
+    },
+    *text(): Operation<string> {
+      return yield* until(response.text());
+    },
+    *arrayBuffer(): Operation<ArrayBuffer> {
+      return yield* until(response.arrayBuffer());
+    },
+    *blob(): Operation<Blob> {
+      return yield* until(response.blob());
+    },
+    *formData(): Operation<FormData> {
+      return yield* until(response.formData());
+    },
+    body(): Stream<Uint8Array, void> {
+      if (!response.body) {
+        throw new Error("Response has no body");
+      }
+
+      return stream(
+        response.body as unknown as AsyncIterable<Uint8Array, void>,
+      );
+    },
+    *expect(): Operation<FetchResponse> {
+      if (!response.ok) {
+        throw new HttpError(
+          response.status,
+          response.statusText,
+          response.url,
+          self,
+        );
+      }
+      return self;
+    },
+  };
+
+  return self;
+}

--- a/fetch/fetch.test.ts
+++ b/fetch/fetch.test.ts
@@ -14,10 +14,12 @@ import {
   call,
   each,
   ensure,
+  spawn,
   withResolvers,
 } from "effection";
 
-import { HttpError, fetch } from "./fetch.ts";
+import { createFetchResponse } from "./create-fetch-response.ts";
+import { FetchApi, HttpError, fetch } from "./mod.ts";
 
 function box<T>(content: () => Operation<T>): Operation<Result<T>> {
   return {
@@ -195,6 +197,85 @@ describe("fetch()", () => {
         .json<{ id: number; title: string }>();
 
       expect(data).toEqual({ id: 1, title: "do things" });
+    });
+  });
+
+  describe("middleware API", () => {
+    it("can intercept requests with logging", function* () {
+      let requestedUrls: string[] = [];
+
+      yield* FetchApi.around({
+        *fetch(args, next) {
+          let [input] = args;
+          requestedUrls.push(String(input));
+          return yield* next(...args);
+        },
+      });
+
+      yield* fetch(`${url}/json`).json();
+      yield* fetch(`${url}/text`).text();
+
+      expect(requestedUrls).toEqual([`${url}/json`, `${url}/text`]);
+    });
+
+    it("can mock responses", function* () {
+      const mockResponse = createFetchResponse(
+        new Response(JSON.stringify({ mocked: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      yield* FetchApi.around({
+        *fetch(args, next) {
+          let [input] = args;
+          if (String(input).includes("/mocked")) {
+            return mockResponse;
+          }
+          return yield* next(...args);
+        },
+      });
+
+      let mockedData = yield* fetch(`${url}/mocked`).json<{
+        mocked: boolean;
+      }>();
+      expect(mockedData).toEqual({ mocked: true });
+
+      let realData = yield* fetch(`${url}/json`).json<{
+        id: number;
+        title: string;
+      }>();
+      expect(realData).toEqual({ id: 1, title: "do things" });
+    });
+
+    it("middleware is scoped and does not leak", function* () {
+      let outerCalls: string[] = [];
+      let innerCalls: string[] = [];
+
+      yield* FetchApi.around({
+        *fetch(args, next) {
+          outerCalls.push("outer");
+          return yield* next(...args);
+        },
+      });
+
+      yield* fetch(`${url}/json`).json();
+
+      let task = yield* spawn(function* () {
+        yield* FetchApi.around({
+          *fetch(args, next) {
+            innerCalls.push("inner");
+            return yield* next(...args);
+          },
+        });
+
+        yield* fetch(`${url}/json`).json();
+      });
+
+      yield* task;
+
+      expect(outerCalls).toEqual(["outer", "outer"]);
+      expect(innerCalls).toEqual(["inner"]);
     });
   });
 });

--- a/fetch/fetch.ts
+++ b/fetch/fetch.ts
@@ -1,10 +1,6 @@
-import {
-  stream,
-  type Operation,
-  type Stream,
-  until,
-  useAbortSignal,
-} from "effection";
+import { type Operation, type Stream } from "effection";
+
+import { coreFetch } from "./api.ts";
 
 /**
  * Request options for fetch, excluding `signal` since cancellation
@@ -167,21 +163,7 @@ function createFetchOperation(
   shouldExpect: boolean,
 ): FetchOperation {
   function* doFetch(): Operation<FetchResponse> {
-    let signal = yield* useAbortSignal();
-
-    let response = yield* until(globalThis.fetch(input, { ...init, signal }));
-    let fetchResponse = createFetchResponse(response);
-
-    if (shouldExpect && !response.ok) {
-      throw new HttpError(
-        response.status,
-        response.statusText,
-        response.url,
-        fetchResponse,
-      );
-    }
-
-    return fetchResponse;
+    return yield* coreFetch(input, init, shouldExpect);
   }
 
   return {
@@ -229,72 +211,3 @@ function createFetchOperation(
   };
 }
 
-function createFetchResponse(response: Response): FetchResponse {
-  let self: FetchResponse = {
-    get ok() {
-      return response.ok;
-    },
-    get status() {
-      return response.status;
-    },
-    get statusText() {
-      return response.statusText;
-    },
-    get headers() {
-      return response.headers;
-    },
-    get url() {
-      return response.url;
-    },
-    get redirected() {
-      return response.redirected;
-    },
-    get type() {
-      return response.type;
-    },
-    get bodyUsed() {
-      return response.bodyUsed;
-    },
-    get raw() {
-      return response;
-    },
-    *json<T = unknown>(parse?: (value: unknown) => T): Operation<T> {
-      let value: unknown = yield* until(response.json());
-      return parse ? parse(value) : (value as T);
-    },
-    *text(): Operation<string> {
-      return yield* until(response.text());
-    },
-    *arrayBuffer(): Operation<ArrayBuffer> {
-      return yield* until(response.arrayBuffer());
-    },
-    *blob(): Operation<Blob> {
-      return yield* until(response.blob());
-    },
-    *formData(): Operation<FormData> {
-      return yield* until(response.formData());
-    },
-    body(): Stream<Uint8Array, void> {
-      if (!response.body) {
-        throw new Error("Response has no body");
-      }
-
-      return stream(
-        response.body as unknown as AsyncIterable<Uint8Array, void>,
-      );
-    },
-    *expect(): Operation<FetchResponse> {
-      if (!response.ok) {
-        throw new HttpError(
-          response.status,
-          response.statusText,
-          response.url,
-          self,
-        );
-      }
-      return self;
-    },
-  };
-
-  return self;
-}

--- a/fetch/fetch.ts
+++ b/fetch/fetch.ts
@@ -210,4 +210,3 @@ function createFetchOperation(
     },
   };
 }
-

--- a/fetch/fetch.ts
+++ b/fetch/fetch.ts
@@ -1,4 +1,4 @@
-import { type Operation, type Stream } from "effection";
+import type { Operation, Stream } from "effection";
 
 import { coreFetch } from "./api.ts";
 

--- a/fetch/mod.ts
+++ b/fetch/mod.ts
@@ -1,1 +1,2 @@
+export * from "./api.ts";
 export * from "./fetch.ts";

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@effectionx/fetch",
   "description": "Effection-native fetch with structured concurrency and streaming response support",
-  "version": "0.1.3",
-  "keywords": ["io", "streams"],
+  "version": "0.2.0",
+  "keywords": ["effection", "effectionx", "io", "fetch", "http", "network"],
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",
@@ -13,6 +13,10 @@
       "import": "./dist/mod.js",
       "default": "./dist/mod.js"
     }
+  },
+  "files": ["dist", "mod.ts", "api.ts", "create-fetch-response.ts", "fetch.ts"],
+  "dependencies": {
+    "@effectionx/context-api": "workspace:*"
   },
   "peerDependencies": {
     "effection": "^3 || ^4"

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -2,7 +2,7 @@
   "name": "@effectionx/fetch",
   "description": "Effection-native fetch with structured concurrency and streaming response support",
   "version": "0.2.0",
-  "keywords": ["effection", "effectionx", "io", "fetch", "http", "network"],
+  "keywords": ["io", "streams"],
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",

--- a/fetch/tsconfig.json
+++ b/fetch/tsconfig.json
@@ -9,6 +9,9 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
+      "path": "../context-api"
+    },
+    {
       "path": "../vitest"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,10 @@ importers:
         version: 4.0.0
 
   fetch:
+    dependencies:
+      '@effectionx/context-api':
+        specifier: workspace:*
+        version: link:../context-api
     devDependencies:
       '@effectionx/vitest':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Convert `@effectionx/fetch` to use Effection's `createApi` pattern, enabling middleware for logging, mocking, and instrumentation.

## Changes

- Add `fetchApi` export with `around()` method for middleware
- Middleware intercepts at the request level (not the builder)
- Add middleware tests for logging, mocking, and scope isolation

## Usage

```ts
import { fetchApi, fetch } from "@effectionx/fetch";
import { run } from "effection";

// Add logging middleware
await run(function* () {
  yield* fetchApi.around({
    *request(args, next) {
      let [input] = args;
      console.log("Fetching:", input);
      return yield* next(...args);
    },
  });

  // All fetch calls in this scope now log
  let data = yield* fetch("/api/users").json();
});
```

## Backward Compatibility

The `fetch()` function remains unchanged. Use `fetchApi.around()` to add middleware that intercepts all requests in the current scope and its children.