### PR TITLE
feat(state-api): add @effectionx/state-api with useState

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@biomejs/biome": "^1",
     "@types/node": "^22",
     "@types/semver": "^7",
-    "effection": "^4",
+    "effection": "4.1.0-alpha.7",
     "expect": "^29",
     "semver": "^7.6.3",
     "vitest": "^4",
@@ -32,6 +32,9 @@
     "peerDependencyRules": {
       "ignoreMissing": [],
       "allowAny": []
+    },
+    "overrides": {
+      "effection": "4.1.0-alpha.7"
     }
   },
   "volta": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@biomejs/biome": "^1",
     "@types/node": "^22",
     "@types/semver": "^7",
-    "effection": "4.1.0-alpha.7",
+    "effection": "^4",
     "expect": "^29",
     "semver": "^7.6.3",
     "vitest": "^4",
@@ -32,9 +32,6 @@
     "peerDependencyRules": {
       "ignoreMissing": [],
       "allowAny": []
-    },
-    "overrides": {
-      "effection": "4.1.0-alpha.7"
     }
   },
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  effection: 4.1.0-alpha.7
-
 importers:
 
   .:
@@ -21,8 +18,8 @@ importers:
         specifier: ^7
         version: 7.7.1
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
       expect:
         specifier: ^29
         version: 29.7.0
@@ -54,8 +51,8 @@ importers:
         specifier: workspace:*
         version: link:../tinyexec
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
       generatorics:
         specifier: ^1
         version: 1.1.0
@@ -76,8 +73,8 @@ importers:
         version: link:../test-adapter
     devDependencies:
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   chain:
     devDependencies:
@@ -85,8 +82,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   context-api:
     dependencies:
@@ -98,8 +95,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   converge:
     dependencies:
@@ -111,8 +108,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   effect-ts:
     devDependencies:
@@ -123,8 +120,8 @@ importers:
         specifier: ^3
         version: 3.19.14
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   fetch:
     dependencies:
@@ -136,8 +133,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   fs:
     dependencies:
@@ -149,8 +146,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   fx:
     devDependencies:
@@ -158,8 +155,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   inline:
     dependencies:
@@ -186,8 +183,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   middleware:
     devDependencies:
@@ -201,8 +198,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   process:
     dependencies:
@@ -235,8 +232,8 @@ importers:
         specifier: ^6
         version: 6.0.6
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   raf:
     devDependencies:
@@ -247,8 +244,8 @@ importers:
         specifier: ^1
         version: 1.2.0
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   scope-eval:
     devDependencies:
@@ -256,8 +253,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   signals:
     dependencies:
@@ -269,17 +266,21 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   state-api:
+    dependencies:
+      '@effectionx/context-api':
+        specifier: workspace:*
+        version: link:../context-api
     devDependencies:
       '@effectionx/bdd':
         specifier: workspace:*
         version: link:../bdd
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   stream-helpers:
     dependencies:
@@ -300,8 +301,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   stream-yaml:
     dependencies:
@@ -316,8 +317,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   task-buffer:
     devDependencies:
@@ -331,14 +332,14 @@ importers:
         specifier: ^8
         version: 8.1.5
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   test-adapter:
     devDependencies:
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   timebox:
     devDependencies:
@@ -346,8 +347,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   tinyexec:
     dependencies:
@@ -356,8 +357,8 @@ importers:
         version: 0.3.2
     devDependencies:
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   vitest:
     dependencies:
@@ -372,8 +373,8 @@ importers:
         specifier: ^7
         version: 7.0.6
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
       vitest:
         specifier: ^4
         version: 4.1.0(@types/node@22.19.7)(vite@7.3.1(@types/node@22.19.7)(yaml@2.8.2))
@@ -412,8 +413,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
   websocket:
     devDependencies:
@@ -424,8 +425,8 @@ importers:
         specifier: ^8
         version: 8.18.1
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
       ws:
         specifier: ^8
         version: 8.19.0
@@ -449,8 +450,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: 4.1.0-alpha.7
-        version: 4.1.0-alpha.7
+        specifier: ^4
+        version: 4.0.2
 
 packages:
 
@@ -1184,8 +1185,8 @@ packages:
   effect@3.19.14:
     resolution: {integrity: sha512-3vwdq0zlvQOxXzXNKRIPKTqZNMyGCdaFUBfMPqpsyzZDre67kgC1EEHDV4EoQTovJ4w5fmJW756f86kkuz7WFA==}
 
-  effection@4.1.0-alpha.7:
-    resolution: {integrity: sha512-ir7qM7vQXOo7eiuNxaD6FgwUetdy3XMB3dwtzUxp9ytiZl6abZUrXwM3vMqKWdMW4cW1KZzJqSEuXofJFscwFw==}
+  effection@4.0.2:
+    resolution: {integrity: sha512-O8WMGP10nPuJDwbNGILcaCNWS+CvDYjcdsUSD79nWZ+WtUQ8h1MEV7JJwCSZCSeKx8+TdEaZ/8r6qPTR2o/o8w==}
     engines: {node: '>= 16'}
 
   es-module-lexer@2.0.0:
@@ -2059,7 +2060,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  effection@4.1.0-alpha.7: {}
+  effection@4.0.2: {}
 
   es-module-lexer@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
     dependencies:
       effection:
         specifier: ^3 || ^4
-        version: 4.0.0
+        version: 4.0.2
     devDependencies:
       '@effectionx/bdd':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,9 +275,9 @@ importers:
         specifier: workspace:*
         version: link:../context-api
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  effection: 4.1.0-alpha.7
+
 importers:
 
   .:
@@ -18,8 +21,8 @@ importers:
         specifier: ^7
         version: 7.7.1
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
       expect:
         specifier: ^29
         version: 29.7.0
@@ -51,8 +54,8 @@ importers:
         specifier: workspace:*
         version: link:../tinyexec
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
       generatorics:
         specifier: ^1
         version: 1.1.0
@@ -73,8 +76,8 @@ importers:
         version: link:../test-adapter
     devDependencies:
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   chain:
     devDependencies:
@@ -82,8 +85,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   context-api:
     dependencies:
@@ -95,8 +98,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   converge:
     dependencies:
@@ -108,8 +111,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   effect-ts:
     devDependencies:
@@ -120,8 +123,8 @@ importers:
         specifier: ^3
         version: 3.19.14
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   fetch:
     dependencies:
@@ -133,8 +136,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   fs:
     dependencies:
@@ -146,8 +149,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   fx:
     devDependencies:
@@ -155,8 +158,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   inline:
     dependencies:
@@ -183,8 +186,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   middleware:
     devDependencies:
@@ -198,8 +201,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   process:
     dependencies:
@@ -232,8 +235,8 @@ importers:
         specifier: ^6
         version: 6.0.6
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   raf:
     devDependencies:
@@ -244,8 +247,8 @@ importers:
         specifier: ^1
         version: 1.2.0
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   scope-eval:
     devDependencies:
@@ -253,8 +256,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   signals:
     dependencies:
@@ -266,8 +269,17 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
+
+  state-api:
+    devDependencies:
+      '@effectionx/bdd':
+        specifier: workspace:*
+        version: link:../bdd
+      effection:
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   stream-helpers:
     dependencies:
@@ -288,8 +300,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   stream-yaml:
     dependencies:
@@ -304,8 +316,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   task-buffer:
     devDependencies:
@@ -319,14 +331,14 @@ importers:
         specifier: ^8
         version: 8.1.5
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   test-adapter:
     devDependencies:
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   timebox:
     devDependencies:
@@ -334,8 +346,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   tinyexec:
     dependencies:
@@ -344,8 +356,8 @@ importers:
         version: 0.3.2
     devDependencies:
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   vitest:
     dependencies:
@@ -360,8 +372,8 @@ importers:
         specifier: ^7
         version: 7.0.6
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
       vitest:
         specifier: ^4
         version: 4.1.0(@types/node@22.19.7)(vite@7.3.1(@types/node@22.19.7)(yaml@2.8.2))
@@ -400,8 +412,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
   websocket:
     devDependencies:
@@ -412,8 +424,8 @@ importers:
         specifier: ^8
         version: 8.18.1
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
       ws:
         specifier: ^8
         version: 8.19.0
@@ -437,8 +449,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       effection:
-        specifier: ^4
-        version: 4.0.0
+        specifier: 4.1.0-alpha.7
+        version: 4.1.0-alpha.7
 
 packages:
 
@@ -1172,8 +1184,8 @@ packages:
   effect@3.19.14:
     resolution: {integrity: sha512-3vwdq0zlvQOxXzXNKRIPKTqZNMyGCdaFUBfMPqpsyzZDre67kgC1EEHDV4EoQTovJ4w5fmJW756f86kkuz7WFA==}
 
-  effection@4.0.0:
-    resolution: {integrity: sha512-eW2yqhyBdey4k8lkp7hpiev2FSHvJvQqvaIebI3EGikHZvfUWvNy7SmkwOnJa6WcsUtSh7VHUwdjHTbV++8M9w==}
+  effection@4.1.0-alpha.7:
+    resolution: {integrity: sha512-ir7qM7vQXOo7eiuNxaD6FgwUetdy3XMB3dwtzUxp9ytiZl6abZUrXwM3vMqKWdMW4cW1KZzJqSEuXofJFscwFw==}
     engines: {node: '>= 16'}
 
   es-module-lexer@2.0.0:
@@ -2047,7 +2059,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  effection@4.0.0: {}
+  effection@4.1.0-alpha.7: {}
 
   es-module-lexer@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ packages:
   - "raf"
   - "scope-eval"
   - "signals"
+  - "state-api"
   - "stream-helpers"
   - "stream-yaml"
   - "task-buffer"

--- a/state-api/README.md
+++ b/state-api/README.md
@@ -1,0 +1,107 @@
+# State API
+
+Reactive state container with typed reducers and middleware for Effection.
+
+---
+
+## Usage
+
+### Basic state
+
+```ts
+import { run, each, spawn } from "effection";
+import { useState } from "@effectionx/state-api";
+
+await run(function* () {
+  const counter = yield* useState(0);
+
+  yield* counter.set(42);
+  yield* counter.update((n) => n + 1);
+  const value = yield* counter.get(); // 43
+});
+```
+
+### Typed reducers
+
+Define named state transitions that are type-safe and interceptable.
+
+```ts
+interface Todo {
+  id: number;
+  text: string;
+  done: boolean;
+}
+
+const todos = yield* useState([] as Todo[], {
+  add: (state, text: string) => [
+    ...state,
+    { id: state.length, text, done: false },
+  ],
+  toggle: (state, id: number) =>
+    state.map((t) => (t.id === id ? { ...t, done: !t.done } : t)),
+  remove: (state, id: number) => state.filter((t) => t.id !== id),
+});
+
+yield* todos.add("buy milk"); // returns the new state
+yield* todos.toggle(0);
+yield* todos.remove(0);
+
+// built-in operations still available
+yield* todos.set([]);
+yield* todos.update((s) => [...s]);
+const snapshot = yield* todos.get();
+```
+
+Each reducer is a function `(state, ...args) => newState`. The `state`
+argument is injected automatically; callers pass only the remaining
+arguments.
+
+### Stream subscription
+
+`State<T>` implements `Stream<T, void>`, so you can subscribe to changes:
+
+```ts
+yield* spawn(function* () {
+  for (const snapshot of yield* each(todos)) {
+    console.log("todos changed:", snapshot);
+    yield* each.next();
+  }
+});
+```
+
+### Middleware
+
+Every operation (`set`, `update`, `get`, and all reducer actions) can be
+intercepted with middleware via `around()`:
+
+```ts
+// log every state change
+yield* todos.around({
+  *set([value], next) {
+    console.log("replacing state:", value);
+    return yield* next(value);
+  },
+  *add([text], next) {
+    console.log("adding todo:", text);
+    return yield* next(text);
+  },
+});
+
+// validate state transitions
+yield* counter.around({
+  *set([value], next) {
+    if (value < 0) throw new Error("counter cannot be negative");
+    return yield* next(value);
+  },
+});
+
+// modify arguments
+yield* counter.around({
+  *update([fn], next) {
+    return yield* next((n) => Math.max(0, fn(n)));
+  },
+});
+```
+
+Middleware is scoped: it applies only within the current Effection scope
+and is automatically removed when the scope exits.

--- a/state-api/README.md
+++ b/state-api/README.md
@@ -26,30 +26,35 @@ await run(function* () {
 Define named state transitions that are type-safe and interceptable.
 
 ```ts
+import { run } from "effection";
+import { useState } from "@effectionx/state-api";
+
 interface Todo {
   id: number;
   text: string;
   done: boolean;
 }
 
-const todos = yield* useState([] as Todo[], {
-  add: (state, text: string) => [
-    ...state,
-    { id: state.length, text, done: false },
-  ],
-  toggle: (state, id: number) =>
-    state.map((t) => (t.id === id ? { ...t, done: !t.done } : t)),
-  remove: (state, id: number) => state.filter((t) => t.id !== id),
+await run(function* () {
+  const todos = yield* useState([] as Todo[], {
+    add: (state, text: string) => [
+      ...state,
+      { id: state.length, text, done: false },
+    ],
+    toggle: (state, id: number) =>
+      state.map((t) => (t.id === id ? { ...t, done: !t.done } : t)),
+    remove: (state, id: number) => state.filter((t) => t.id !== id),
+  });
+
+  yield* todos.add("buy milk"); // returns the new state
+  yield* todos.toggle(0);
+  yield* todos.remove(0);
+
+  // built-in operations still available
+  yield* todos.set([]);
+  yield* todos.update((s) => [...s]);
+  const snapshot = yield* todos.get();
 });
-
-yield* todos.add("buy milk"); // returns the new state
-yield* todos.toggle(0);
-yield* todos.remove(0);
-
-// built-in operations still available
-yield* todos.set([]);
-yield* todos.update((s) => [...s]);
-const snapshot = yield* todos.get();
 ```
 
 Each reducer is a function `(state, ...args) => newState`. The `state`
@@ -58,9 +63,11 @@ arguments.
 
 ### Stream subscription
 
-`State<T>` implements `Stream<T, void>`, so you can subscribe to changes:
+`State<T>` implements `Stream<T, void>`, so you can subscribe to changes.
+The following continues from the `todos` example above:
 
 ```ts
+// inside run(function* () { ... })
 yield* spawn(function* () {
   for (const snapshot of yield* each(todos)) {
     console.log("todos changed:", snapshot);
@@ -75,6 +82,8 @@ Every operation (`set`, `update`, `get`, and all reducer actions) can be
 intercepted with middleware via `around()`:
 
 ```ts
+// inside run(function* () { ... })
+
 // log every state change
 yield* todos.around({
   *set([value], next) {

--- a/state-api/mod.ts
+++ b/state-api/mod.ts
@@ -1,0 +1,2 @@
+export { useState } from "./state.ts";
+export type { State, ReducerMap } from "./state.ts";

--- a/state-api/package.json
+++ b/state-api/package.json
@@ -23,11 +23,14 @@
   },
   "files": ["dist", "mod.ts", "state.ts"],
   "peerDependencies": {
-    "effection": "^4.1.0-alpha.3"
+    "effection": "^3 || ^4"
+  },
+  "dependencies": {
+    "@effectionx/context-api": "workspace:*"
   },
   "devDependencies": {
     "@effectionx/bdd": "workspace:*",
-    "effection": "4.1.0-alpha.7"
+    "effection": "^4"
   },
   "license": "MIT",
   "author": "engineering@frontside.com",

--- a/state-api/package.json
+++ b/state-api/package.json
@@ -29,7 +29,7 @@
     "@effectionx/context-api": "workspace:*"
   },
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   },
   "license": "MIT",

--- a/state-api/package.json
+++ b/state-api/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@effectionx/state-api",
+  "description": "Reactive state container with typed reducers and middleware for Effection",
+  "version": "0.1.0",
+  "keywords": [
+    "effection",
+    "effectionx",
+    "state",
+    "reducer",
+    "middleware",
+    "reactive"
+  ],
+  "type": "module",
+  "main": "./dist/mod.js",
+  "types": "./dist/mod.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/mod.d.ts",
+      "development": "./mod.ts",
+      "import": "./dist/mod.js",
+      "default": "./dist/mod.js"
+    }
+  },
+  "files": ["dist", "mod.ts", "state.ts"],
+  "peerDependencies": {
+    "effection": "^4.1.0-alpha.3"
+  },
+  "devDependencies": {
+    "@effectionx/bdd": "workspace:*",
+    "effection": "4.1.0-alpha.7"
+  },
+  "license": "MIT",
+  "author": "engineering@frontside.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thefrontside/effectionx.git"
+  },
+  "bugs": {
+    "url": "https://github.com/thefrontside/effectionx/issues"
+  },
+  "sideEffects": false
+}

--- a/state-api/state.test.ts
+++ b/state-api/state.test.ts
@@ -1,0 +1,316 @@
+import { describe, it } from "@effectionx/bdd";
+import { each, scoped, sleep, spawn, withResolvers } from "effection";
+import { expect } from "expect";
+
+import { useState } from "./mod.ts";
+
+describe("useState", () => {
+  describe("basic operations", () => {
+    it("sets initial state accessible via get", function* () {
+      const counter = yield* useState(0);
+      expect(yield* counter.get()).toEqual(0);
+    });
+
+    it("set() replaces state and returns the new state", function* () {
+      const counter = yield* useState(0);
+      const result = yield* counter.set(42);
+      expect(result).toEqual(42);
+      expect(yield* counter.get()).toEqual(42);
+    });
+
+    it("update() transforms state and returns the new state", function* () {
+      const counter = yield* useState(10);
+      const result = yield* counter.update((n) => n + 5);
+      expect(result).toEqual(15);
+      expect(yield* counter.get()).toEqual(15);
+    });
+
+    it("supports complex object state", function* () {
+      const state = yield* useState({ count: 0, name: "test" });
+      yield* state.set({ count: 1, name: "updated" });
+      expect(yield* state.get()).toEqual({ count: 1, name: "updated" });
+    });
+
+    it("supports destructured operations", function* () {
+      const counter = yield* useState(0);
+      const { set, update, get } = counter;
+      yield* set(10);
+      expect(yield* get()).toEqual(10);
+      yield* update((n) => n * 2);
+      expect(yield* get()).toEqual(20);
+    });
+  });
+
+  describe("stream", () => {
+    it("emits new state on set()", function* () {
+      const counter = yield* useState(0);
+      const values: number[] = [];
+      const { resolve, operation } = withResolvers<void>();
+
+      yield* spawn(function* () {
+        for (const value of yield* each(counter)) {
+          values.push(value);
+          if (values.length === 3) {
+            resolve();
+          }
+          yield* each.next();
+        }
+      });
+
+      // allow subscriber to establish
+      yield* sleep(0);
+
+      yield* counter.set(1);
+      yield* counter.set(2);
+      yield* counter.set(3);
+
+      yield* operation;
+      expect(values).toEqual([1, 2, 3]);
+    });
+
+    it("emits new state on update()", function* () {
+      const counter = yield* useState(0);
+      const values: number[] = [];
+      const { resolve, operation } = withResolvers<void>();
+
+      yield* spawn(function* () {
+        for (const value of yield* each(counter)) {
+          values.push(value);
+          if (values.length === 2) {
+            resolve();
+          }
+          yield* each.next();
+        }
+      });
+
+      yield* sleep(0);
+
+      yield* counter.update((n) => n + 1);
+      yield* counter.update((n) => n + 10);
+
+      yield* operation;
+      expect(values).toEqual([1, 11]);
+    });
+  });
+
+  describe("reducers", () => {
+    it("creates typed reducer actions", function* () {
+      const counter = yield* useState(0, {
+        increment: (state, amount: number) => state + amount,
+        decrement: (state, amount: number) => state - amount,
+        reset: () => 0,
+      });
+
+      const afterInc = yield* counter.increment(5);
+      expect(afterInc).toEqual(5);
+
+      const afterDec = yield* counter.decrement(2);
+      expect(afterDec).toEqual(3);
+
+      const afterReset = yield* counter.reset();
+      expect(afterReset).toEqual(0);
+    });
+
+    it("reducer actions emit to stream", function* () {
+      const counter = yield* useState(0, {
+        increment: (state, amount: number) => state + amount,
+      });
+      const values: number[] = [];
+      const { resolve, operation } = withResolvers<void>();
+
+      yield* spawn(function* () {
+        for (const value of yield* each(counter)) {
+          values.push(value);
+          if (values.length === 3) {
+            resolve();
+          }
+          yield* each.next();
+        }
+      });
+
+      yield* sleep(0);
+
+      yield* counter.increment(1);
+      yield* counter.increment(2);
+      yield* counter.increment(3);
+
+      yield* operation;
+      expect(values).toEqual([1, 3, 6]);
+    });
+
+    it("works with complex object state", function* () {
+      interface Todo {
+        id: number;
+        text: string;
+        done: boolean;
+      }
+
+      const todos = yield* useState([] as Todo[], {
+        add: (state, text: string) => [
+          ...state,
+          { id: state.length, text, done: false },
+        ],
+        toggle: (state, id: number) =>
+          state.map((t) => (t.id === id ? { ...t, done: !t.done } : t)),
+        remove: (state, id: number) => state.filter((t) => t.id !== id),
+      });
+
+      yield* todos.add("buy milk");
+      yield* todos.add("write tests");
+
+      const afterToggle = yield* todos.toggle(0);
+      expect(afterToggle).toEqual([
+        { id: 0, text: "buy milk", done: true },
+        { id: 1, text: "write tests", done: false },
+      ]);
+
+      const afterRemove = yield* todos.remove(0);
+      expect(afterRemove).toEqual([
+        { id: 1, text: "write tests", done: false },
+      ]);
+    });
+
+    it("built-in set/update still work alongside reducers", function* () {
+      const counter = yield* useState(0, {
+        increment: (state, amount: number) => state + amount,
+      });
+
+      yield* counter.increment(5);
+      expect(yield* counter.get()).toEqual(5);
+
+      yield* counter.set(100);
+      expect(yield* counter.get()).toEqual(100);
+
+      yield* counter.update((n) => n - 1);
+      expect(yield* counter.get()).toEqual(99);
+    });
+  });
+
+  describe("middleware", () => {
+    it("intercepts set() calls", function* () {
+      const counter = yield* useState(0);
+      const log: string[] = [];
+
+      yield* counter.around({
+        *set([value], next) {
+          log.push(`setting to ${value}`);
+          return yield* next(value);
+        },
+      });
+
+      yield* counter.set(42);
+      expect(log).toEqual(["setting to 42"]);
+      expect(yield* counter.get()).toEqual(42);
+    });
+
+    it("intercepts update() calls", function* () {
+      const counter = yield* useState(10);
+      const log: string[] = [];
+
+      yield* counter.around({
+        *update([updater], next) {
+          log.push("updating");
+          return yield* next(updater);
+        },
+      });
+
+      yield* counter.update((n) => n + 5);
+      expect(log).toEqual(["updating"]);
+      expect(yield* counter.get()).toEqual(15);
+    });
+
+    it("intercepts reducer actions by name", function* () {
+      const counter = yield* useState(0, {
+        increment: (state, amount: number) => state + amount,
+      });
+      const log: string[] = [];
+
+      yield* counter.around({
+        *increment([amount], next) {
+          log.push(`incrementing by ${amount}`);
+          return yield* next(amount);
+        },
+      });
+
+      yield* counter.increment(5);
+      expect(log).toEqual(["incrementing by 5"]);
+      expect(yield* counter.get()).toEqual(5);
+    });
+
+    it("middleware can modify arguments", function* () {
+      const counter = yield* useState(0, {
+        increment: (state, amount: number) => state + amount,
+      });
+
+      yield* counter.around({
+        *increment([amount], next) {
+          // double the increment
+          return yield* next(amount * 2);
+        },
+      });
+
+      yield* counter.increment(5);
+      expect(yield* counter.get()).toEqual(10);
+    });
+
+    it("middleware can modify the return value", function* () {
+      const counter = yield* useState(0);
+
+      yield* counter.around({
+        *get(_args, next) {
+          const value = yield* next();
+          // middleware returns a different value
+          return value + 1000;
+        },
+      });
+
+      // the real state is 0, but middleware adds 1000
+      expect(yield* counter.get()).toEqual(1000);
+    });
+
+    it("middleware is scoped and does not leak", function* () {
+      const counter = yield* useState(0);
+      const log: string[] = [];
+
+      yield* scoped(function* () {
+        yield* counter.around({
+          *set([value], next) {
+            log.push(`inner: ${value}`);
+            return yield* next(value);
+          },
+        });
+
+        yield* counter.set(1);
+        expect(log).toEqual(["inner: 1"]);
+      });
+
+      // After leaving the scoped block, middleware is gone
+      log.length = 0;
+      yield* counter.set(2);
+      expect(log).toEqual([]);
+      expect(yield* counter.get()).toEqual(2);
+    });
+
+    it("chains multiple middleware", function* () {
+      const counter = yield* useState(0);
+      const log: string[] = [];
+
+      yield* counter.around({
+        *set([value], next) {
+          log.push("first");
+          return yield* next(value);
+        },
+      });
+
+      yield* counter.around({
+        *set([value], next) {
+          log.push("second");
+          return yield* next(value);
+        },
+      });
+
+      yield* counter.set(1);
+      expect(log).toEqual(["first", "second"]);
+    });
+  });
+});

--- a/state-api/state.test.ts
+++ b/state-api/state.test.ts
@@ -57,7 +57,7 @@ describe("useState", () => {
         }
       });
 
-      // allow subscriber to establish
+      // yield control to let subscriber establish (sleep(0) is policy-compliant)
       yield* sleep(0);
 
       yield* counter.set(1);
@@ -83,6 +83,7 @@ describe("useState", () => {
         }
       });
 
+      // yield control to let subscriber establish (sleep(0) is policy-compliant)
       yield* sleep(0);
 
       yield* counter.update((n) => n + 1);
@@ -128,6 +129,7 @@ describe("useState", () => {
         }
       });
 
+      // yield control to let subscriber establish (sleep(0) is policy-compliant)
       yield* sleep(0);
 
       yield* counter.increment(1);
@@ -168,6 +170,19 @@ describe("useState", () => {
       expect(afterRemove).toEqual([
         { id: 1, text: "write tests", done: false },
       ]);
+    });
+
+    it("rejects reserved reducer names", function* () {
+      for (const name of ["set", "update", "get", "around"]) {
+        let error: Error | undefined;
+        try {
+          yield* useState(0, { [name]: (state: number) => state });
+        } catch (e) {
+          error = e as Error;
+        }
+        expect(error).toBeDefined();
+        expect(error?.message).toContain(`"${name}" is reserved`);
+      }
     });
 
     it("built-in set/update still work alongside reducers", function* () {

--- a/state-api/state.test.ts
+++ b/state-api/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { each, scoped, sleep, spawn, withResolvers } from "effection";
 import { expect } from "expect";
 

--- a/state-api/state.ts
+++ b/state-api/state.ts
@@ -7,7 +7,9 @@ import { type Api, createApi } from "@effectionx/context-api";
  * Each reducer takes the current state as the first argument,
  * followed by any additional arguments, and returns the new state.
  */
-// biome-ignore lint/suspicious/noExplicitAny: reducer args must be open-ended
+// `any[]` is intentional here so concrete reducer args (e.g. `number`, `string`)
+// are assignable under strict function parameter variance.
+// biome-ignore lint/suspicious/noExplicitAny: see rationale above
 export type ReducerMap<T> = Record<string, (state: T, ...args: any[]) => T>;
 
 /**
@@ -60,23 +62,6 @@ export type State<T, R extends ReducerMap<T> = Record<never, never>> = Stream<
 };
 
 /**
- * Create a reactive state container.
- *
- * @param initial - The initial state value
- * @returns An `Operation` that yields a `State<T>` container
- *
- * @example Basic usage
- * ```ts
- * const counter = yield* useState(0);
- *
- * yield* counter.set(42);
- * yield* counter.update(n => n + 1);
- * const value = yield* counter.get();
- * ```
- */
-export function useState<T>(initial: T): Operation<State<T>>;
-
-/**
  * Create a reactive state container with typed reducer actions.
  *
  * @param initial - The initial state value
@@ -84,7 +69,8 @@ export function useState<T>(initial: T): Operation<State<T>>;
  *   Each reducer takes `(state, ...args)` and returns a new state.
  *   The `state` parameter is injected automatically — callers
  *   only pass the remaining arguments.
- * @returns An `Operation` that yields a `State<T, R>` container
+ * @returns An `Operation` that yields a `State<T, R>` container.
+ *   If `reducers` are omitted, `R` defaults to `Record<never, never>`.
  *
  * @example With reducers
  * ```ts
@@ -115,73 +101,93 @@ export function useState<T>(initial: T): Operation<State<T>>;
  * });
  * ```
  */
+type EmptyReducers = Record<never, never>;
+type ReducerHandlers<T, R extends ReducerMap<T>> = {
+  [K in keyof R]: (...args: ActionArgs<R[K]>) => Operation<T>;
+};
+
+export function useState<T>(initial: T): Operation<State<T, EmptyReducers>>;
 export function useState<T, R extends ReducerMap<T>>(
   initial: T,
   reducers: R,
 ): Operation<State<T, R>>;
-
-// biome-ignore lint/suspicious/noExplicitAny: overload implementation
-export function useState<T>(initial: T, reducers?: any): Operation<any> {
+export function useState<T, R extends ReducerMap<T>>(
+  initial: T,
+  reducers?: R,
+): Operation<State<T, EmptyReducers> | State<T, R>> {
   return resource(function* (provide) {
     const signal = createSignal<T, void>();
     const ref = { current: initial };
 
-    // Build the core handler object for createApi.
-    // Built-in operations: set, update, get
-    // biome-ignore lint/suspicious/noExplicitAny: dynamic handler construction
-    const core: Record<string, (...args: any[]) => Operation<T>> = {
-      *set(value: T): Operation<T> {
-        ref.current = value;
-        signal.send(value);
-        return ref.current;
-      },
-      *update(updater: (value: T) => T): Operation<T> {
-        ref.current = updater(ref.current);
-        signal.send(ref.current);
-        return ref.current;
-      },
-      *get(): Operation<T> {
-        return ref.current;
-      },
-    };
-
-    // Add user-defined reducer actions
-    const reserved = new Set(["set", "update", "get", "around"]);
-    if (reducers) {
-      for (const key of Object.keys(reducers)) {
+    function createState<RLocal extends ReducerMap<T>>(
+      stateReducers: RLocal,
+    ): State<T, RLocal> {
+      // Add user-defined reducer actions
+      const reserved = new Set(["set", "update", "get", "around"]);
+      for (let key of Object.keys(stateReducers)) {
         if (reserved.has(key)) {
           throw new Error(
             `Reducer name "${key}" is reserved. Built-in operations (set, update, get, around) cannot be overridden.`,
           );
         }
-        const reducer = reducers[key];
-        // biome-ignore lint/suspicious/noExplicitAny: reducer args are open-ended
-        core[key] = function* (...args: any[]): Operation<T> {
-          ref.current = reducer(ref.current, ...args);
+      }
+
+      const core: CoreHandlers<T, RLocal> = {
+        *set(value: T): Operation<T> {
+          ref.current = value;
+          signal.send(value);
+          return ref.current;
+        },
+        *update(updater: (value: T) => T): Operation<T> {
+          ref.current = updater(ref.current);
           signal.send(ref.current);
           return ref.current;
-        };
-      }
+        },
+        *get(): Operation<T> {
+          return ref.current;
+        },
+        ...createReducerHandlers(stateReducers, ref, signal),
+      };
+
+      const api = createApi("state", core);
+
+      // Build the flattened State object
+      return {
+        // Stream interface
+        [Symbol.iterator]: signal[Symbol.iterator],
+        // Middleware
+        around: api.around,
+        // Spread all operations (set, update, valueOf, + reducers)
+        ...api.operations,
+      } as State<T, RLocal>;
     }
 
-    // biome-ignore lint/suspicious/noExplicitAny: dynamic core object
-    const api = createApi("state", core as any);
-
-    // Build the flattened State object
-    const state = {
-      // Stream interface
-      [Symbol.iterator]: signal[Symbol.iterator],
-      // Middleware
-      around: api.around,
-      // Spread all operations (set, update, valueOf, + reducers)
-      ...api.operations,
-      // biome-ignore lint/suspicious/noExplicitAny: cast to match overload return type
-    } as any;
-
     try {
+      const state = reducers
+        ? createState(reducers)
+        : createState({} as EmptyReducers);
       yield* provide(state);
     } finally {
       signal.close();
     }
   });
+}
+
+function createReducerHandlers<T, R extends ReducerMap<T>>(
+  reducers: R,
+  ref: { current: T },
+  signal: ReturnType<typeof createSignal<T, void>>,
+): ReducerHandlers<T, R> {
+  let handlers = {} as ReducerHandlers<T, R>;
+
+  for (let key of Object.keys(reducers) as Array<keyof R>) {
+    let reducer = reducers[key];
+    handlers[key] = function* (...args: ActionArgs<R[typeof key]>) {
+      ref.current = reducer(ref.current, ...args);
+      signal.send(ref.current);
+      return ref.current;
+    } as ReducerHandlers<T, R>[typeof key];
+  }
+
+  return handlers;
 }

--- a/state-api/state.ts
+++ b/state-api/state.ts
@@ -1,11 +1,5 @@
-import {
-  type Api,
-  type Operation,
-  type Stream,
-  createSignal,
-  resource,
-} from "effection";
-import { createApi } from "effection/experimental";
+import { type Operation, type Stream, createSignal, resource } from "effection";
+import { type Api, createApi } from "@effectionx/context-api";
 
 /**
  * A map of reducer functions: `(state, ...args) => newState`

--- a/state-api/state.ts
+++ b/state-api/state.ts
@@ -152,8 +152,14 @@ export function useState<T>(initial: T, reducers?: any): Operation<any> {
     };
 
     // Add user-defined reducer actions
+    const reserved = new Set(["set", "update", "get", "around"]);
     if (reducers) {
       for (const key of Object.keys(reducers)) {
+        if (reserved.has(key)) {
+          throw new Error(
+            `Reducer name "${key}" is reserved. Built-in operations (set, update, get, around) cannot be overridden.`,
+          );
+        }
         const reducer = reducers[key];
         // biome-ignore lint/suspicious/noExplicitAny: reducer args are open-ended
         core[key] = function* (...args: any[]): Operation<T> {

--- a/state-api/state.ts
+++ b/state-api/state.ts
@@ -1,0 +1,187 @@
+import {
+  type Api,
+  type Operation,
+  type Stream,
+  createSignal,
+  resource,
+} from "effection";
+import { createApi } from "effection/experimental";
+
+/**
+ * A map of reducer functions: `(state, ...args) => newState`
+ *
+ * Each reducer takes the current state as the first argument,
+ * followed by any additional arguments, and returns the new state.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: reducer args must be open-ended
+export type ReducerMap<T> = Record<string, (state: T, ...args: any[]) => T>;
+
+/**
+ * Strip the leading `state` parameter from a reducer function,
+ * leaving only the user-facing arguments.
+ */
+type ActionArgs<F> = F extends (state: never, ...args: infer A) => unknown
+  ? A
+  : never;
+
+/**
+ * The core handler object that gets passed to `createApi`.
+ *
+ * Built-in operations (`set`, `update`, `get`) plus
+ * one operation per user-defined reducer action.
+ */
+type CoreHandlers<T, R extends ReducerMap<T>> = {
+  set(value: T): Operation<T>;
+  update(updater: (value: T) => T): Operation<T>;
+  get(): Operation<T>;
+} & {
+  [K in keyof R]: (...args: ActionArgs<R[K]>) => Operation<T>;
+};
+
+/**
+ * A reactive state container with middleware support.
+ *
+ * Provides built-in `set`, `update`, and `get` operations,
+ * plus any user-defined reducer actions. All operations return
+ * `Operation<T>` where `T` is the state type, yielding the
+ * resulting state after the operation.
+ *
+ * Also implements `Stream<T, void>` so you can subscribe to
+ * state changes using `each`.
+ */
+export type State<T, R extends ReducerMap<T> = Record<never, never>> = Stream<
+  T,
+  void
+> & {
+  /** Replace the current state. Returns the new state. */
+  set(value: T): Operation<T>;
+  /** Transform the current state. Returns the new state. */
+  update(updater: (value: T) => T): Operation<T>;
+  /** Read the current state. */
+  get(): Operation<T>;
+  /** Install middleware on this state container. */
+  around: Api<CoreHandlers<T, R>>["around"];
+} & {
+  [K in keyof R]: (...args: ActionArgs<R[K]>) => Operation<T>;
+};
+
+/**
+ * Create a reactive state container.
+ *
+ * @param initial - The initial state value
+ * @returns An `Operation` that yields a `State<T>` container
+ *
+ * @example Basic usage
+ * ```ts
+ * const counter = yield* useState(0);
+ *
+ * yield* counter.set(42);
+ * yield* counter.update(n => n + 1);
+ * const value = yield* counter.get();
+ * ```
+ */
+export function useState<T>(initial: T): Operation<State<T>>;
+
+/**
+ * Create a reactive state container with typed reducer actions.
+ *
+ * @param initial - The initial state value
+ * @param reducers - An object of named reducer functions.
+ *   Each reducer takes `(state, ...args)` and returns a new state.
+ *   The `state` parameter is injected automatically — callers
+ *   only pass the remaining arguments.
+ * @returns An `Operation` that yields a `State<T, R>` container
+ *
+ * @example With reducers
+ * ```ts
+ * interface Todo { id: number; text: string; done: boolean; }
+ *
+ * const todos = yield* useState([] as Todo[], {
+ *   add: (state, text: string) => [
+ *     ...state,
+ *     { id: state.length, text, done: false },
+ *   ],
+ *   toggle: (state, id: number) =>
+ *     state.map(t => t.id === id ? { ...t, done: !t.done } : t),
+ *   remove: (state, id: number) =>
+ *     state.filter(t => t.id !== id),
+ * });
+ *
+ * const afterAdd = yield* todos.add("buy milk");
+ * const afterToggle = yield* todos.toggle(0);
+ * ```
+ *
+ * @example With middleware
+ * ```ts
+ * yield* todos.around({
+ *   *add([text], next) {
+ *     console.log("Adding:", text);
+ *     return yield* next(text);
+ *   },
+ * });
+ * ```
+ */
+export function useState<T, R extends ReducerMap<T>>(
+  initial: T,
+  reducers: R,
+): Operation<State<T, R>>;
+
+// biome-ignore lint/suspicious/noExplicitAny: overload implementation
+export function useState<T>(initial: T, reducers?: any): Operation<any> {
+  return resource(function* (provide) {
+    const signal = createSignal<T, void>();
+    const ref = { current: initial };
+
+    // Build the core handler object for createApi.
+    // Built-in operations: set, update, get
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic handler construction
+    const core: Record<string, (...args: any[]) => Operation<T>> = {
+      *set(value: T): Operation<T> {
+        ref.current = value;
+        signal.send(value);
+        return ref.current;
+      },
+      *update(updater: (value: T) => T): Operation<T> {
+        ref.current = updater(ref.current);
+        signal.send(ref.current);
+        return ref.current;
+      },
+      *get(): Operation<T> {
+        return ref.current;
+      },
+    };
+
+    // Add user-defined reducer actions
+    if (reducers) {
+      for (const key of Object.keys(reducers)) {
+        const reducer = reducers[key];
+        // biome-ignore lint/suspicious/noExplicitAny: reducer args are open-ended
+        core[key] = function* (...args: any[]): Operation<T> {
+          ref.current = reducer(ref.current, ...args);
+          signal.send(ref.current);
+          return ref.current;
+        };
+      }
+    }
+
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic core object
+    const api = createApi("state", core as any);
+
+    // Build the flattened State object
+    const state = {
+      // Stream interface
+      [Symbol.iterator]: signal[Symbol.iterator],
+      // Middleware
+      around: api.around,
+      // Spread all operations (set, update, valueOf, + reducers)
+      ...api.operations,
+      // biome-ignore lint/suspicious/noExplicitAny: cast to match overload return type
+    } as any;
+
+    try {
+      yield* provide(state);
+    } finally {
+      signal.close();
+    }
+  });
+}

--- a/state-api/tsconfig.json
+++ b/state-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.test.ts", "dist"],
+  "references": [
+    {
+      "path": "../bdd"
+    }
+  ]
+}

--- a/state-api/tsconfig.json
+++ b/state-api/tsconfig.json
@@ -9,6 +9,9 @@
   "references": [
     {
       "path": "../bdd"
+    },
+    {
+      "path": "../context-api"
     }
   ]
 }

--- a/state-api/tsconfig.json
+++ b/state-api/tsconfig.json
@@ -8,10 +8,10 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../context-api"
     },
     {
-      "path": "../context-api"
+      "path": "../vitest"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     { "path": "raf" },
     { "path": "scope-eval" },
     { "path": "signals" },
+    { "path": "state-api" },
     { "path": "stream-helpers" },
     { "path": "stream-yaml" },
     { "path": "task-buffer" },


### PR DESCRIPTION
# Motivation

Add a reactive state container primitive to EffectionX that supports typed reducer actions and per-container middleware. This fills a gap between the existing `@effectionx/signals` (synchronous mutations, no middleware) and the API pattern used by fetch/process/fs (stateless operations).

`useState` provides a reducer-like API inspired by React's `useReducer` and TC39 Signals, where state transitions are named, type-safe, and interceptable.

# Approach

New package `@effectionx/state-api` with a single entry point: `useState<T>(initial, reducers?)`.

- Each `useState()` call creates its own `createApi` instance from `@effectionx/context-api`, so middleware installed on one container does not affect others.
- Built-in operations: `set(value)`, `update(fn)`, `get()` — all return `Operation<T>` for the resulting state.
- User-defined reducer actions follow `(state, ...args) => newState`; the `state` argument is injected and callers pass only the remaining args.
- `State<T>` implements `Stream<T, void>` for subscribing to changes via `each`.
- Middleware uses `around()` from `@effectionx/context-api`, keeping the package on the monorepo's stable Effection version instead of pinning the repo to `effection/experimental`.

## Validation

- `node --env-file=.env --test state-api/state.test.ts`
- `pnpm check:tsrefs`
- `pnpm lint`
- `pnpm fmt:check`
- `pnpm check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new State API package providing reactive state management with useState, typed reducers, stream subscriptions, and middleware support.

* **Documentation**
  * Added comprehensive State API docs with usage examples, middleware patterns, and scoping semantics.

* **Tests**
  * Added extensive test coverage validating state operations, streams, reducers, and middleware behavior.

* **Chores**
  * Registered the State API package in the workspace and added its package manifest and build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->