### PR TITLE
node test to vitest migration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Run tests
+      - name: Run tests bdd
         run: pnpm test:node
 
       - name: Run tests
@@ -91,7 +91,7 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Run tests
+      - name: Run tests bdd
         run: pnpm test:node
 
       - name: Run tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,9 @@ jobs:
         run: pnpm build
 
       - name: Run tests
+        run: pnpm test:node
+
+      - name: Run tests
         run: pnpm test
 
       - name: Run peer dependency matrix tests
@@ -87,6 +90,9 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Run tests
+        run: pnpm test:node
 
       - name: Run tests
         run: pnpm test

--- a/.internal/test-matrix.ts
+++ b/.internal/test-matrix.ts
@@ -259,6 +259,8 @@ function* runTestsWithVitest(
     "--env-file=.env",
     "./node_modules/vitest/vitest.mjs",
     "run",
+    "--config",
+    "vitest.config.ts",
     `--reporter=default`,
     `--reporter=json`,
     `--outputFile=${vitestReportPath}`,
@@ -332,7 +334,7 @@ function* runTestsWithVitest(
   const passed = report?.numPassedTests ?? 0;
   const failed = Math.max(report?.numFailedTests ?? 0, failures.length);
   const skipped = (report?.numPendingTests ?? 0) + (report?.numTodoTests ?? 0);
-  const total = Math.max(report?.numTotalTests ?? 0, passed + failed + skipped);
+  const total = report?.numTotalTests ?? passed + failed + skipped;
 
   return {
     overrides,
@@ -378,9 +380,7 @@ function printSummaryTable(results: MatrixResult[]): void {
 
   for (const result of results) {
     const status =
-      result.failed === 0
-        ? "\x1b[32mPASS\x1b[0m"
-        : "\x1b[31mFAIL\x1b[0m";
+      result.failed === 0 ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
 
     const attempted = result.passed + result.failed;
     const rate =

--- a/.internal/test-matrix.ts
+++ b/.internal/test-matrix.ts
@@ -33,11 +33,35 @@ type MatrixResult = {
   overrides: Record<string, string>;
   packages: string[];
   failures: { name: string; error?: string }[];
+  passed: number;
+  failed: number;
+  skipped: number;
+  total: number;
   exitCode: number;
+};
+
+type VitestAssertionResult = {
+  fullName: string;
+  status: "passed" | "failed" | "pending" | "skipped" | "todo";
+  failureMessages: string[];
+};
+
+type VitestFileResult = {
+  assertionResults: VitestAssertionResult[];
+};
+
+type VitestJsonReport = {
+  numTotalTests: number;
+  numPassedTests: number;
+  numFailedTests: number;
+  numPendingTests: number;
+  numTodoTests: number;
+  testResults: VitestFileResult[];
 };
 
 const rootDir = process.cwd();
 const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+const vitestReportPath = path.join(rootDir, ".internal", "vitest-matrix-report.json");
 
 function groupStart(title: string): void {
   if (isGitHubActions) {
@@ -231,10 +255,16 @@ function* runTestsWithVitest(
     "--env-file=.env",
     "./node_modules/vitest/vitest.mjs",
     "run",
+    `--reporter=json`,
+    `--outputFile=${vitestReportPath}`,
     ...testPatterns,
   ];
   if (verbose) {
-    arguments_.splice(3, 0, "--reporter=verbose");
+    arguments_.splice(5, 0, "--reporter=verbose");
+  }
+
+  if (fs.existsSync(vitestReportPath)) {
+    fs.unlinkSync(vitestReportPath);
   }
 
   // Run vitest through node with .env loaded so matrix runs use the same
@@ -256,6 +286,27 @@ function* runTestsWithVitest(
     }
   }
 
+  let report: VitestJsonReport | null = null;
+  if (fs.existsSync(vitestReportPath)) {
+    report = JSON.parse(
+      yield* readTextFile(vitestReportPath),
+    ) as VitestJsonReport;
+    fs.unlinkSync(vitestReportPath);
+  }
+
+  if (report) {
+    for (const file of report.testResults) {
+      for (const assertion of file.assertionResults) {
+        if (assertion.status === "failed") {
+          failures.push({
+            name: assertion.fullName,
+            error: assertion.failureMessages[0],
+          });
+        }
+      }
+    }
+  }
+
   if (exitCode !== 0) {
     const diagnostic = [stderr, stdout]
       .filter(Boolean)
@@ -263,18 +314,31 @@ function* runTestsWithVitest(
       .trim()
       .slice(0, 1600);
 
-    failures.push({
-      name: "vitest run failed",
-      error: diagnostic
-        ? `vitest exited with code ${exitCode}\n${diagnostic}`
-        : `vitest exited with code ${exitCode}`,
-    });
+    if (failures.length === 0) {
+      failures.push({
+        name: "vitest run failed",
+        error: diagnostic
+          ? `vitest exited with code ${exitCode}\n${diagnostic}`
+          : `vitest exited with code ${exitCode}`,
+      });
+    }
   }
+
+  const passed = report?.numPassedTests ?? 0;
+  const failed = report?.numFailedTests ?? failures.length;
+  const skipped =
+    (report?.numPendingTests ?? 0) +
+    (report?.numTodoTests ?? 0);
+  const total = report?.numTotalTests ?? passed + failed + skipped;
 
   return {
     overrides,
     packages,
     failures,
+    passed,
+    failed,
+    skipped,
+    total,
     exitCode,
   };
 }
@@ -294,7 +358,7 @@ function printSummaryTable(results: MatrixResult[]): void {
   console.log(`${"=".repeat(70)}\n`);
 
   // Dynamic header based on which deps are being tested
-  const cols = [...keys, "Packages", "Failed", "Status"];
+  const cols = [...keys, "Packages", "Passed", "Failed", "Skipped", "Rate", "Status"];
   const widths = cols.map((c) => Math.max(c.length + 2, 12));
 
   const header = cols.map((c, i) => c.padEnd(widths[i])).join("");
@@ -307,10 +371,18 @@ function printSummaryTable(results: MatrixResult[]): void {
         ? "\x1b[32mPASS\x1b[0m"
         : "\x1b[31mFAIL\x1b[0m";
 
+    const attempted = result.passed + result.failed;
+    const rate = attempted === 0
+      ? "-"
+      : `${Math.round((result.passed / attempted) * 100)}%`;
+
     const values = [
       ...keys.map((k) => result.overrides[k] ?? "-"),
       String(result.packages.length),
+      String(result.passed),
       String(result.failures.length),
+      String(result.skipped),
+      rate,
       status,
     ];
 

--- a/.internal/test-matrix.ts
+++ b/.internal/test-matrix.ts
@@ -71,12 +71,13 @@ const fetchPackageVersions = function* (
   if (cached) {
     return cached;
   }
-  console.log(`  Fetching ${packageName} versions from npm...`);
+
   const { stdout } = yield* runCommand(
     `npm view ${packageName} versions --json`,
   );
   const versions = JSON.parse(stdout) as string[];
   versionCache.set(packageName, versions);
+
   return versions;
 };
 
@@ -129,6 +130,7 @@ const getWorkspacePackages = function* (): Operation<PackageInfo[]> {
 
     if (pkg.peerDependencies) {
       for (const [depName, range] of Object.entries(pkg.peerDependencies)) {
+        groupStart(`Fetching ${depName} versions from npm...`);
         const allVersions = yield* fetchPackageVersions(depName);
         const { min, max } = resolveVersionPair(allVersions, range);
 
@@ -137,6 +139,7 @@ const getWorkspacePackages = function* (): Operation<PackageInfo[]> {
 
         peerDeps.push({ name: depName, range, versions });
         console.log(`    ${pkg.name} -> ${depName}: ${versions.join(", ")}`);
+        groupEnd();
       }
     }
 
@@ -350,15 +353,11 @@ await main(function* () {
   console.log("Peer Dependency Matrix Test Runner");
   console.log("===================================\n");
 
-  groupStart("Resolve packages and peer dependencies");
   console.log("Resolving packages and peer dependencies...");
   const packages = yield* getWorkspacePackages();
-  groupEnd();
 
-  groupStart("Generate test matrix");
   console.log("Generating test matrix...");
   const matrix = generateMatrix(packages);
-  groupEnd();
 
   if (matrix.length === 0) {
     console.log("No packages with peer dependencies found.");
@@ -427,8 +426,8 @@ await main(function* () {
   // Set exit code if any failures
   const hasFailures = results.some((r) => r.failures.length > 0);
   if (hasFailures) {
+    process.exitCode = 1;
     console.log("\n\x1b[31mMatrix tests failed!\x1b[0m");
-    process.exit(1);
   } else {
     console.log("\n\x1b[32mAll matrix tests passed!\x1b[0m");
   }

--- a/.internal/test-matrix.ts
+++ b/.internal/test-matrix.ts
@@ -128,8 +128,8 @@ const getWorkspacePackages = function* (): Operation<PackageInfo[]> {
     const peerDeps: PeerDepVersions[] = [];
 
     if (pkg.peerDependencies) {
+      groupStart(`Fetching ${pkg.name} peer dep versions from npm...`);
       for (const [depName, range] of Object.entries(pkg.peerDependencies)) {
-        groupStart(`Fetching ${depName} versions from npm...`);
         const allVersions = yield* fetchPackageVersions(depName);
         const { min, max } = resolveVersionPair(allVersions, range);
 
@@ -138,8 +138,8 @@ const getWorkspacePackages = function* (): Operation<PackageInfo[]> {
 
         peerDeps.push({ name: depName, range, versions });
         console.log(`    ${pkg.name} -> ${depName}: ${versions.join(", ")}`);
-        groupEnd();
       }
+      groupEnd();
     }
 
     packages.push({ name: pkg.name, dir, peerDeps });
@@ -294,7 +294,7 @@ function printSummaryTable(results: MatrixResult[]): void {
   console.log(`${"=".repeat(70)}\n`);
 
   // Dynamic header based on which deps are being tested
-  const cols = [...keys, "Packages", "Passed", "Failed", "Status"];
+  const cols = [...keys, "Packages", "Failed", "Status"];
   const widths = cols.map((c) => Math.max(c.length + 2, 12));
 
   const header = cols.map((c, i) => c.padEnd(widths[i])).join("");
@@ -414,11 +414,9 @@ await main(function* () {
   yield* runCommand("pnpm install --no-frozen-lockfile");
   groupEnd();
 
-  groupStart("Matrix summary");
   // Print summary
   printSummaryTable(results);
   printFailureDetails(results);
-  groupEnd();
 
   // Set exit code if any failures
   const hasFailures = results.some((r) => r.failures.length > 0);

--- a/.internal/test-matrix.ts
+++ b/.internal/test-matrix.ts
@@ -330,9 +330,9 @@ function* runTestsWithVitest(
   }
 
   const passed = report?.numPassedTests ?? 0;
-  const failed = report?.numFailedTests ?? failures.length;
+  const failed = Math.max(report?.numFailedTests ?? 0, failures.length);
   const skipped = (report?.numPendingTests ?? 0) + (report?.numTodoTests ?? 0);
-  const total = report?.numTotalTests ?? passed + failed + skipped;
+  const total = Math.max(report?.numTotalTests ?? 0, passed + failed + skipped);
 
   return {
     overrides,
@@ -378,7 +378,7 @@ function printSummaryTable(results: MatrixResult[]): void {
 
   for (const result of results) {
     const status =
-      result.failures.length === 0
+      result.failed === 0
         ? "\x1b[32mPASS\x1b[0m"
         : "\x1b[31mFAIL\x1b[0m";
 
@@ -392,7 +392,7 @@ function printSummaryTable(results: MatrixResult[]): void {
       ...keys.map((k) => result.overrides[k] ?? "-"),
       String(result.packages.length),
       String(result.passed),
-      String(result.failures.length),
+      String(result.failed),
       String(result.skipped),
       rate,
       status,
@@ -476,9 +476,9 @@ await main(function* () {
     results.push(result);
 
     const status =
-      result.failures.length === 0
+      result.failed === 0
         ? "\x1b[32mPASS\x1b[0m"
-        : `\x1b[31mFAIL (${result.failures.length} failures)\x1b[0m`;
+        : `\x1b[31mFAIL (${result.failed} failures)\x1b[0m`;
     console.log(`\nCompleted: ${status}`);
     groupEnd();
   }
@@ -503,7 +503,7 @@ await main(function* () {
   printFailureDetails(results);
 
   // Set exit code if any failures
-  const hasFailures = results.some((r) => r.failures.length > 0);
+  const hasFailures = results.some((r) => r.failed > 0);
   if (hasFailures) {
     process.exitCode = 1;
     console.log("\n\x1b[31mMatrix tests failed!\x1b[0m");

--- a/.internal/test-matrix.ts
+++ b/.internal/test-matrix.ts
@@ -33,7 +33,6 @@ type MatrixResult = {
   overrides: Record<string, string>;
   packages: string[];
   failures: { name: string; error?: string }[];
-  passed: number;
   exitCode: number;
 };
 
@@ -276,7 +275,6 @@ function* runTestsWithVitest(
     overrides,
     packages,
     failures,
-    passed: exitCode === 0 ? 1 : 0,
     exitCode,
   };
 }
@@ -312,7 +310,6 @@ function printSummaryTable(results: MatrixResult[]): void {
     const values = [
       ...keys.map((k) => result.overrides[k] ?? "-"),
       String(result.packages.length),
-      String(result.passed),
       String(result.failures.length),
       status,
     ];
@@ -398,7 +395,7 @@ await main(function* () {
       result.failures.length === 0
         ? "\x1b[32mPASS\x1b[0m"
         : `\x1b[31mFAIL (${result.failures.length} failures)\x1b[0m`;
-    console.log(`\nCompleted: ${result.passed} passed, ${status}`);
+    console.log(`\nCompleted: ${status}`);
     groupEnd();
   }
 

--- a/.internal/test-matrix.ts
+++ b/.internal/test-matrix.ts
@@ -3,39 +3,13 @@ import path from "node:path";
 import process from "node:process";
 import { readTextFile } from "@effectionx/fs";
 import { exec } from "@effectionx/process";
-import { lines } from "@effectionx/stream-helpers";
-import { type Operation, type Stream, each, main, spawn } from "effection";
+import { type Operation, main } from "effection";
 import G from "generatorics";
 import semver from "semver";
 
 // Parse CLI args for verbose mode
 const verbose =
   process.argv.includes("-v") || process.argv.includes("--verbose");
-
-import { type TapTestResult, parseTapResults } from "./tap-parser.ts";
-
-/**
- * Stream helper that logs each line as it passes through.
- * Used in verbose mode to see raw TAP output.
- */
-function logLines<TClose>(
-  stream: Stream<string, TClose>,
-): Stream<string, TClose> {
-  return {
-    *[Symbol.iterator]() {
-      const sub = yield* stream;
-      return {
-        *next() {
-          const result = yield* sub.next();
-          if (!result.done) {
-            console.log(result.value);
-          }
-          return result;
-        },
-      };
-    },
-  };
-}
 
 // Types for peer dependency version resolution
 type PeerDepVersions = {
@@ -58,12 +32,27 @@ type MatrixEntry = {
 type MatrixResult = {
   overrides: Record<string, string>;
   packages: string[];
-  failures: TapTestResult[];
+  failures: { name: string; error?: string }[];
   passed: number;
   exitCode: number;
 };
 
 const rootDir = process.cwd();
+const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+
+function groupStart(title: string): void {
+  if (isGitHubActions) {
+    console.log(`::group::${title.replace(/\r?\n/g, " ")}`);
+  } else {
+    console.log(`\n>>> ${title}`);
+  }
+}
+
+function groupEnd(): void {
+  if (isGitHubActions) {
+    console.log("::endgroup::");
+  }
+}
 
 const runCommand = (command: string) => exec(command).expect();
 
@@ -221,74 +210,71 @@ const generateMatrix = (packages: PackageInfo[]): MatrixEntry[] => {
   });
 };
 
-function* runTestsWithTap(
+function* runTestsWithVitest(
   overrides: Record<string, string>,
   packages: string[],
 ): Operation<MatrixResult> {
-  const failures: TapTestResult[] = [];
-  let passed = 0;
+  const failures: { name: string; error?: string }[] = [];
 
-  // Build glob patterns for test files from package names
-  // Package names are like @effectionx/fx -> fx/**/*.test.ts
+  // Build package path filters from package names.
+  // We intentionally pass directories (e.g. "fx") rather than glob strings
+  // like "fx/**/*.test.ts" because this command is executed without a shell,
+  // so globs are not expanded before reaching Vitest.
   const testPatterns = packages.map((pkg) => {
     const shortName = pkg.replace("@effectionx/", "");
-    return `${shortName}/**/*.test.ts`;
+    return shortName;
   });
 
-  // Build command with TAP reporter
-  const baseNodeOptions = process.env.NODE_OPTIONS ?? "";
-  const tapNodeOptions = `${baseNodeOptions} --test-reporter=tap`.trim();
+  const arguments_ = [
+    "--env-file=.env",
+    "./node_modules/vitest/vitest.mjs",
+    "run",
+    ...testPatterns,
+  ];
+  if (verbose) {
+    arguments_.splice(3, 0, "--reporter=verbose");
+  }
 
-  // Pass arguments separately to avoid shell: true which doesn't work on Windows
-  const proc = yield* exec("node", {
-    arguments: ["--test", ...testPatterns],
+  // Run vitest through node with .env loaded so matrix runs use the same
+  // runtime conditions as the root `pnpm test` command.
+  const { code, stdout, stderr } = yield* exec("node", {
+    arguments: arguments_,
     env: {
       ...process.env,
-      NODE_OPTIONS: tapNodeOptions,
-    },
-  });
+    } as Record<string, string>,
+  }).join();
+  const exitCode = code ?? 1;
 
-  // Process stdout in real-time
-  yield* spawn(function* () {
-    const lineStream = lines()(proc.stdout);
-    // In verbose mode, log each line as it passes through
-    const loggedStream = verbose ? logLines(lineStream) : lineStream;
-    const tapStream = parseTapResults()(loggedStream);
-
-    for (const result of yield* each(tapStream)) {
-      // Skip suites, only count actual tests
-      // Tests either have type: 'test' or no type field (but not type: 'suite')
-      const isTest = result.metadata?.type !== "suite";
-
-      if (isTest) {
-        if (result.status === "not ok") {
-          // Skip suite-level failures (they just aggregate subtest failures)
-          if (result.metadata?.failureType !== "subtestsFailed") {
-            failures.push(result);
-            console.log(`  \x1b[31m\u2717 ${result.name}\x1b[0m`);
-            if (result.metadata?.error) {
-              // Print first line of error indented
-              const errorLines = result.metadata.error.split("\n");
-              console.log(`    \x1b[90m${errorLines[0]}\x1b[0m`);
-            }
-          }
-        } else {
-          passed++;
-        }
-      }
-      yield* each.next();
+  if (verbose && (stdout || stderr)) {
+    if (stdout) {
+      console.log(stdout);
     }
-  });
+    if (stderr) {
+      console.error(stderr);
+    }
+  }
 
-  // Wait for process to complete
-  const { code } = yield* proc.join();
+  if (exitCode !== 0) {
+    const diagnostic = [stderr, stdout]
+      .filter(Boolean)
+      .join("\n")
+      .trim()
+      .slice(0, 1600);
+
+    failures.push({
+      name: "vitest run failed",
+      error: diagnostic
+        ? `vitest exited with code ${exitCode}\n${diagnostic}`
+        : `vitest exited with code ${exitCode}`,
+    });
+  }
 
   return {
     overrides,
     packages,
     failures,
-    passed,
-    exitCode: code ?? 1,
+    passed: exitCode === 0 ? 1 : 0,
+    exitCode,
   };
 }
 
@@ -353,24 +339,8 @@ function printFailureDetails(results: MatrixResult[]): void {
 
     for (const failure of result.failures) {
       console.log(`\n\x1b[31m[${overrideStr}]\x1b[0m ${failure.name}`);
-
-      if (failure.metadata?.location) {
-        console.log(`  Location: ${failure.metadata.location}`);
-      }
-
-      if (failure.metadata?.error) {
-        console.log(`  Error: ${failure.metadata.error}`);
-      }
-
-      if (failure.metadata?.stack) {
-        console.log("  Stack:");
-        const stackLines = failure.metadata.stack.split("\n");
-        for (const line of stackLines.slice(0, 5)) {
-          console.log(`    ${line}`);
-        }
-        if (stackLines.length > 5) {
-          console.log(`    ... (${stackLines.length - 5} more lines)`);
-        }
+      if (failure.error) {
+        console.log(`  Error: ${failure.error}`);
       }
     }
   }
@@ -380,11 +350,15 @@ await main(function* () {
   console.log("Peer Dependency Matrix Test Runner");
   console.log("===================================\n");
 
+  groupStart("Resolve packages and peer dependencies");
   console.log("Resolving packages and peer dependencies...");
   const packages = yield* getWorkspacePackages();
+  groupEnd();
 
-  console.log("\nGenerating test matrix...");
+  groupStart("Generate test matrix");
+  console.log("Generating test matrix...");
   const matrix = generateMatrix(packages);
+  groupEnd();
 
   if (matrix.length === 0) {
     console.log("No packages with peer dependencies found.");
@@ -395,10 +369,12 @@ await main(function* () {
 
   const results: MatrixResult[] = [];
 
-  for (const entry of matrix) {
+  for (const [index, entry] of matrix.entries()) {
     const overrideStr = Object.entries(entry.overrides)
       .map(([k, v]) => `${k}@${v}`)
       .join(", ");
+
+    groupStart(`Matrix ${index + 1}/${matrix.length}: ${overrideStr}`);
 
     console.log(`\n${"=".repeat(60)}`);
     console.log(`Testing with: ${overrideStr}`);
@@ -416,7 +392,7 @@ await main(function* () {
     yield* runCommand("pnpm install --no-frozen-lockfile");
 
     console.log("[3/3] Running tests...\n");
-    const result = yield* runTestsWithTap(entry.overrides, entry.packages);
+    const result = yield* runTestsWithVitest(entry.overrides, entry.packages);
     results.push(result);
 
     const status =
@@ -424,8 +400,10 @@ await main(function* () {
         ? "\x1b[32mPASS\x1b[0m"
         : `\x1b[31mFAIL (${result.failures.length} failures)\x1b[0m`;
     console.log(`\nCompleted: ${result.passed} passed, ${status}`);
+    groupEnd();
   }
 
+  groupStart("Cleanup and restore dependencies");
   console.log(`\n${"=".repeat(60)}`);
   console.log("Cleaning up...");
   console.log("=".repeat(60));
@@ -438,16 +416,19 @@ await main(function* () {
   }
 
   yield* runCommand("pnpm install --no-frozen-lockfile");
+  groupEnd();
 
+  groupStart("Matrix summary");
   // Print summary
   printSummaryTable(results);
   printFailureDetails(results);
+  groupEnd();
 
   // Set exit code if any failures
   const hasFailures = results.some((r) => r.failures.length > 0);
   if (hasFailures) {
-    process.exitCode = 1;
     console.log("\n\x1b[31mMatrix tests failed!\x1b[0m");
+    process.exit(1);
   } else {
     console.log("\n\x1b[32mAll matrix tests passed!\x1b[0m");
   }

--- a/.internal/test-matrix.ts
+++ b/.internal/test-matrix.ts
@@ -61,7 +61,11 @@ type VitestJsonReport = {
 
 const rootDir = process.cwd();
 const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
-const vitestReportPath = path.join(rootDir, ".internal", "vitest-matrix-report.json");
+const vitestReportPath = path.join(
+  rootDir,
+  ".internal",
+  "vitest-matrix-report.json",
+);
 
 function groupStart(title: string): void {
   if (isGitHubActions) {
@@ -255,12 +259,13 @@ function* runTestsWithVitest(
     "--env-file=.env",
     "./node_modules/vitest/vitest.mjs",
     "run",
+    `--reporter=default`,
     `--reporter=json`,
     `--outputFile=${vitestReportPath}`,
     ...testPatterns,
   ];
   if (verbose) {
-    arguments_.splice(5, 0, "--reporter=verbose");
+    arguments_.splice(6, 0, "--reporter=verbose");
   }
 
   if (fs.existsSync(vitestReportPath)) {
@@ -326,9 +331,7 @@ function* runTestsWithVitest(
 
   const passed = report?.numPassedTests ?? 0;
   const failed = report?.numFailedTests ?? failures.length;
-  const skipped =
-    (report?.numPendingTests ?? 0) +
-    (report?.numTodoTests ?? 0);
+  const skipped = (report?.numPendingTests ?? 0) + (report?.numTodoTests ?? 0);
   const total = report?.numTotalTests ?? passed + failed + skipped;
 
   return {
@@ -358,7 +361,15 @@ function printSummaryTable(results: MatrixResult[]): void {
   console.log(`${"=".repeat(70)}\n`);
 
   // Dynamic header based on which deps are being tested
-  const cols = [...keys, "Packages", "Passed", "Failed", "Skipped", "Rate", "Status"];
+  const cols = [
+    ...keys,
+    "Packages",
+    "Passed",
+    "Failed",
+    "Skipped",
+    "Rate",
+    "Status",
+  ];
   const widths = cols.map((c) => Math.max(c.length + 2, 12));
 
   const header = cols.map((c, i) => c.padEnd(widths[i])).join("");
@@ -372,9 +383,10 @@ function printSummaryTable(results: MatrixResult[]): void {
         : "\x1b[31mFAIL\x1b[0m";
 
     const attempted = result.passed + result.failed;
-    const rate = attempted === 0
-      ? "-"
-      : `${Math.round((result.passed / attempted) * 100)}%`;
+    const rate =
+      attempted === 0
+        ? "-"
+        : `${Math.round((result.passed / attempted) * 100)}%`;
 
     const values = [
       ...keys.map((k) => result.overrides[k] ?? "-"),

--- a/.policies/deterministic-tests.md
+++ b/.policies/deterministic-tests.md
@@ -23,7 +23,7 @@ This document defines the experimental policy for writing stable, non-flaky test
 ### Compliant: Lifecycle invariant assertion
 
 ```typescript
-import { describe, it, expect } from "@effectionx/bdd";
+import { describe, it, expect } from "@effectionx/vitest";
 import { spawn, suspend, resource } from "effection";
 
 it("runs cleanup on halt", function* () {
@@ -48,7 +48,7 @@ it("runs cleanup on halt", function* () {
 ### Compliant: Using withResolvers for callback synchronization
 
 ```typescript
-import { describe, it, expect } from "@effectionx/bdd";
+import { describe, it, expect } from "@effectionx/vitest";
 import { spawn, withResolvers } from "effection";
 
 it("notifies on connection", function* () {

--- a/bdd/bdd.test.ts
+++ b/bdd/bdd.test.ts
@@ -1,11 +1,12 @@
-import { describe, it } from "vitest";
+import { describe, it } from "@effectionx/bdd";
+import { sleep } from "effection";
 
 describe("@effectionx/bdd", () => {
-  it("should run basic test", () => {
+  it("should run basic test", function* () {
     // passes
   });
 
-  it("should support async operations", async () => {
-    await new Promise((resolve) => setTimeout(resolve, 1));
+  it("should support Effection operations", function* () {
+    yield* sleep(1);
   });
 });

--- a/bdd/bdd.test.ts
+++ b/bdd/bdd.test.ts
@@ -1,12 +1,11 @@
-import { describe, it } from "@effectionx/bdd";
-import { sleep } from "effection";
+import { describe, it } from "vitest";
 
 describe("@effectionx/bdd", () => {
-  it("should run basic test", function* () {
+  it("should run basic test", () => {
     // passes
   });
 
-  it("should support Effection operations", function* () {
-    yield* sleep(1);
+  it("should support async operations", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1));
   });
 });

--- a/chain/chain.test.ts
+++ b/chain/chain.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import type { Operation } from "effection";
 

--- a/chain/package.json
+++ b/chain/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/chain/tsconfig.json
+++ b/chain/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/context-api/context-api.test.ts
+++ b/context-api/context-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { createApi } from "@effectionx/context-api";
 import { type Operation, scoped } from "effection";
 import { expect } from "expect";

--- a/context-api/package.json
+++ b/context-api/package.json
@@ -32,7 +32,7 @@
   "sideEffects": false,
   "files": ["dist", "mod.ts"],
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/context-api/scope-middleware.test.ts
+++ b/context-api/scope-middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { createApi } from "@effectionx/context-api";
 import { type Operation, scoped, spawn, withResolvers } from "effection";
 import { expect } from "expect";

--- a/context-api/tsconfig.json
+++ b/context-api/tsconfig.json
@@ -8,10 +8,10 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../middleware"
     },
     {
-      "path": "../middleware"
+      "path": "../vitest"
     }
   ]
 }

--- a/converge/converge.test.ts
+++ b/converge/converge.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { sleep, spawn } from "effection";
 import { expect } from "expect";
 

--- a/converge/package.json
+++ b/converge/package.json
@@ -31,7 +31,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/converge/tsconfig.json
+++ b/converge/tsconfig.json
@@ -8,10 +8,10 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../timebox"
     },
     {
-      "path": "../timebox"
+      "path": "../vitest"
     }
   ]
 }

--- a/effect-ts/effect.test.ts
+++ b/effect-ts/effect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { Context, Effect, Exit, Fiber, Layer } from "effect";
 import { call, scoped, sleep, spawn, suspend, withResolvers } from "effection";
 import { expect } from "expect";

--- a/effect-ts/package.json
+++ b/effect-ts/package.json
@@ -19,7 +19,7 @@
     "effection": "^3 || ^4"
   },
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effect": "^3",
     "effection": "^4"
   },

--- a/effect-ts/tsconfig.json
+++ b/effect-ts/tsconfig.json
@@ -6,5 +6,9 @@
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.test.ts", "dist"],
-  "references": [{ "path": "../bdd" }]
+  "references": [
+    {
+      "path": "../vitest"
+    }
+  ]
 }

--- a/fetch/fetch.test.ts
+++ b/fetch/fetch.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it } from "@effectionx/bdd";
+import { beforeEach, describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 
 import {

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/fetch/tsconfig.json
+++ b/fetch/tsconfig.json
@@ -7,5 +7,9 @@
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.test.ts", "dist"],
-  "references": [{ "path": "../bdd" }]
+  "references": [
+    {
+      "path": "../vitest"
+    }
+  ]
 }

--- a/fs/fs.test.ts
+++ b/fs/fs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from "@effectionx/bdd";
+import { describe, it, beforeEach } from "@effectionx/vitest";
 import { expect } from "expect";
 import { each, until } from "effection";
 import * as path from "node:path";

--- a/fs/package.json
+++ b/fs/package.json
@@ -18,7 +18,7 @@
     "effection": "^3 || ^4"
   },
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   },
   "license": "MIT",

--- a/fs/tsconfig.json
+++ b/fs/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/fx/package.json
+++ b/fx/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/fx/parallel.test.ts
+++ b/fx/parallel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { Err, Ok, each, sleep, spawn, until } from "effection";
 import { expect } from "expect";
 

--- a/fx/race.test.ts
+++ b/fx/race.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { sleep } from "effection";
 import { expect } from "expect";
 

--- a/fx/request.test.ts
+++ b/fx/request.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it } from "@effectionx/bdd";
+import { beforeEach, describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 
 import {

--- a/fx/safe.test.ts
+++ b/fx/safe.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { call } from "effection";
 import { expect } from "expect";
 

--- a/fx/tsconfig.json
+++ b/fx/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/jsonl-store/context.test.ts
+++ b/jsonl-store/context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { useStore } from "./mod.ts";
 import { expect } from "expect";
 

--- a/jsonl-store/jsonl.test.ts
+++ b/jsonl-store/jsonl.test.ts
@@ -2,7 +2,7 @@ import * as fsp from "node:fs/promises";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { beforeEach, describe, it } from "@effectionx/bdd";
+import { beforeEach, describe, it } from "@effectionx/vitest";
 import { each, until } from "effection";
 import { expect } from "expect";
 

--- a/jsonl-store/package.json
+++ b/jsonl-store/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/jsonl-store/tsconfig.json
+++ b/jsonl-store/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/middleware/middleware.test.ts
+++ b/middleware/middleware.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import { type Middleware, combine } from "./mod.ts";
 
 describe("combine", () => {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -24,5 +24,8 @@
   "bugs": {
     "url": "https://github.com/thefrontside/effectionx/issues"
   },
+  "devDependencies": {
+    "@effectionx/vitest": "workspace:*"
+  },
   "sideEffects": false
 }

--- a/node/package.json
+++ b/node/package.json
@@ -40,7 +40,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/node/stream.test.ts
+++ b/node/stream.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { each } from "effection";
 import { expect } from "expect";
 

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:tsc": "tsc --build",
     "check": "tsc -b --emitDeclarationOnly && tsc -p tsconfig.check.json",
     "test": "node --env-file=.env ./node_modules/vitest/vitest.mjs run",
-    "test:node": "node --env-file=.env --test \"**/*.test.ts\"",
+    "test:node": "node --env-file=.env --test \"bdd/*.test.ts\"",
     "test:matrix": "node --env-file=.env .internal/test-matrix.ts",
     "lint": "biome lint .",
     "fmt": "biome format . --write",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "pnpm run build:tsc && turbo run build:bundle",
     "build:tsc": "tsc --build",
     "check": "tsc -b --emitDeclarationOnly && tsc -p tsconfig.check.json",
-    "test": "node --env-file=.env --test \"**/*.test.ts\"",
+    "test": "node --env-file=.env ./node_modules/vitest/vitest.mjs run",
+    "test:node": "node --env-file=.env --test \"**/*.test.ts\"",
     "test:matrix": "node --env-file=.env .internal/test-matrix.ts",
     "lint": "biome lint .",
     "fmt": "biome format . --write",
@@ -23,6 +24,7 @@
     "effection": "^4",
     "expect": "^29",
     "semver": "^7.6.3",
+    "vitest": "^4",
     "turbo": "^2",
     "typescript": "^5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,12 @@ importers:
         specifier: workspace:*
         version: link:../test-adapter
     devDependencies:
+      '@types/cross-spawn':
+        specifier: ^6
+        version: 6.0.6
+      cross-spawn:
+        specifier: ^7
+        version: 7.0.6
       effection:
         specifier: ^4
         version: 4.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4
+        version: 4.1.0(@types/node@22.19.7)(vite@7.3.1(@types/node@22.19.7)(yaml@2.8.2))
 
   .internal:
     dependencies:
@@ -75,9 +78,9 @@ importers:
 
   chain:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
@@ -88,9 +91,9 @@ importers:
         specifier: workspace:*
         version: link:../middleware
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
@@ -101,18 +104,18 @@ importers:
         specifier: workspace:*
         version: link:../timebox
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
 
   effect-ts:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effect:
         specifier: ^3
         version: 3.19.14
@@ -122,47 +125,51 @@ importers:
 
   fetch:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
 
   fs:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
 
   fx:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
 
   jsonl-store:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
 
-  middleware: {}
+  middleware:
+    devDependencies:
+      '@effectionx/vitest':
+        specifier: workspace:*
+        version: link:../vitest
 
   node:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
@@ -188,12 +195,12 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
     devDependencies:
-      '@effectionx/bdd':
-        specifier: workspace:*
-        version: link:../bdd
       '@effectionx/stream-helpers':
         specifier: workspace:*
         version: link:../stream-helpers
+      '@effectionx/vitest':
+        specifier: workspace:*
+        version: link:../vitest
       '@types/cross-spawn':
         specifier: ^6
         version: 6.0.6
@@ -203,9 +210,9 @@ importers:
 
   raf:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       '@essentials/raf':
         specifier: ^1
         version: 1.2.0
@@ -215,9 +222,9 @@ importers:
 
   scope-eval:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
@@ -228,9 +235,9 @@ importers:
         specifier: ^5
         version: 5.1.4
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
@@ -250,9 +257,9 @@ importers:
         specifier: ^2
         version: 2.33.4
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
@@ -263,21 +270,21 @@ importers:
         specifier: ^2
         version: 2.8.2
     devDependencies:
-      '@effectionx/bdd':
-        specifier: workspace:*
-        version: link:../bdd
       '@effectionx/stream-helpers':
         specifier: workspace:*
         version: link:../stream-helpers
+      '@effectionx/vitest':
+        specifier: workspace:*
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
 
   task-buffer:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       '@sinonjs/fake-timers':
         specifier: ^14
         version: 14.0.0
@@ -296,9 +303,9 @@ importers:
 
   timebox:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
@@ -319,12 +326,6 @@ importers:
         specifier: workspace:*
         version: link:../test-adapter
     devDependencies:
-      '@effectionx/bdd':
-        specifier: workspace:*
-        version: link:../bdd
-      '@effectionx/process':
-        specifier: workspace:*
-        version: link:../process
       effection:
         specifier: ^4
         version: 4.0.0
@@ -356,24 +357,24 @@ importers:
         specifier: ^0
         version: 0.1.8
     devDependencies:
-      '@effectionx/bdd':
-        specifier: workspace:*
-        version: link:../bdd
       '@effectionx/signals':
         specifier: workspace:*
         version: link:../signals
       '@effectionx/stream-helpers':
         specifier: workspace:*
         version: link:../stream-helpers
+      '@effectionx/vitest':
+        specifier: workspace:*
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0
 
   websocket:
     devDependencies:
-      '@effectionx/bdd':
+      '@effectionx/vitest':
         specifier: workspace:*
-        version: link:../bdd
+        version: link:../vitest
       '@types/ws':
         specifier: ^8
         version: 8.18.1
@@ -396,12 +397,12 @@ importers:
         specifier: ^1
         version: 1.5.0
     devDependencies:
-      '@effectionx/bdd':
-        specifier: workspace:*
-        version: link:../bdd
       '@effectionx/converge':
         specifier: workspace:*
         version: link:../converge
+      '@effectionx/vitest':
+        specifier: workspace:*
+        version: link:../vitest
       effection:
         specifier: ^4
         version: 4.0.0

--- a/process/package.json
+++ b/process/package.json
@@ -36,7 +36,7 @@
     "shellwords-ts": "^3.0.1"
   },
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "@effectionx/stream-helpers": "workspace:*",
     "@types/cross-spawn": "^6",
     "effection": "^4"

--- a/process/test/daemon.test.ts
+++ b/process/test/daemon.test.ts
@@ -1,5 +1,5 @@
 import process from "node:process";
-import { beforeEach, describe, it } from "@effectionx/bdd";
+import { beforeEach, describe, it } from "@effectionx/vitest";
 import { type Task, sleep, spawn, until, withResolvers } from "effection";
 import { expect } from "expect";
 

--- a/process/test/eventemitter.test.ts
+++ b/process/test/eventemitter.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { spawn, withResolvers } from "effection";
 import { expect } from "expect";
 

--- a/process/test/exec.test.ts
+++ b/process/test/exec.test.ts
@@ -1,5 +1,5 @@
 import process from "node:process";
-import { beforeEach, describe, it } from "@effectionx/bdd";
+import { beforeEach, describe, it } from "@effectionx/vitest";
 import { type Task, sleep, spawn, withResolvers } from "effection";
 import { expect } from "expect";
 

--- a/process/test/output-stream.test.ts
+++ b/process/test/output-stream.test.ts
@@ -1,6 +1,6 @@
 // import { expect } from "expect";
 // import { createSignal, each, spawn } from "effection";
-// import { describe, it } from "@effectionx/bdd";
+// import { describe, it } from "@effectionx/vitest";
 
 // import { createOutputStream } from "../src/output-stream.ts";
 // import { Buffer } from "node:buffer";

--- a/process/test/output-stream.test.ts
+++ b/process/test/output-stream.test.ts
@@ -1,73 +1,61 @@
-// import { expect } from "expect";
+import { describe, it } from "@effectionx/vitest";
 // import { createSignal, each, spawn } from "effection";
-// import { describe, it } from "@effectionx/vitest";
 
 // import { createOutputStream } from "../src/output-stream.ts";
 // import { Buffer } from "node:buffer";
 
-// const b = (value: string) => Buffer.from(value, "utf8");
-
-// describe("createOutputStream", () => {
-//   it("can be created from regular stream", function* () {
-//     const stream = createSignal<Buffer, void>();
-
-//     let ioStream = createOutputStream(stream);
-//     let values: Buffer[] = [];
-
-//     yield* spawn(function* () {
-//       for (const value of yield* each(ioStream)) {
-//         values.push(value);
-//         yield* each.next();
-//       }
-//     });
-
-//     stream.send(b("foo"));
-//     stream.send(b("bar"));
-//     stream.send(b("baz"));
-
-//     expect(values).toEqual([b("foo"), b("bar"), b("baz")]);
-//   });
-// });
-
-// describe("text()", () => {
-//   it("maps output to string", function* () {
-//     const stream = createSignal<Buffer, void>();
-//     let ioStream = createOutputStream(stream);
-//     let values: string[] = [];
-
-//     yield* spawn(function* () {
-//       for (const value of yield* each(ioStream.text())) {
-//         values.push(value);
-//         yield* each.next();
-//       }
-//     });
-
-//     stream.send(b("foo"));
-//     stream.send(b("bar"));
-//     stream.send(b("baz"));
-
-//     expect(values).toEqual(["foo", "bar", "baz"]);
-//   });
-// });
-
-// describe("lines()", () => {
-//   it("combines output into complete lines", function* () {
-//     const stream = createSignal<Buffer, void>();
-//     let ioStream = createOutputStream(stream);
-//     let values: string[] = [];
-
-//     yield* spawn(function* () {
-//       for (const value of yield* each(ioStream.lines())) {
-//         values.push(value);
-//         yield* each.next();
-//       }
-//     });
-
-//     stream.send(b("foo\nhello"));
-//     stream.send(b("world\n"));
-//     stream.send(b("something"));
-//     stream.close();
-
-//     expect(values).toEqual(["foo", "helloworld", "something"]);
-//   });
-// });
+describe.skip("createOutputStream", () => {
+  // const b = (value: string) => Buffer.from(value, "utf8");
+  // describe("createOutputStream", () => {
+  //   it("can be created from regular stream", function* () {
+  //     const stream = createSignal<Buffer, void>();
+  //     let ioStream = createOutputStream(stream);
+  //     let values: Buffer[] = [];
+  //     yield* spawn(function* () {
+  //       for (const value of yield* each(ioStream)) {
+  //         values.push(value);
+  //         yield* each.next();
+  //       }
+  //     });
+  //     stream.send(b("foo"));
+  //     stream.send(b("bar"));
+  //     stream.send(b("baz"));
+  //     expect(values).toEqual([b("foo"), b("bar"), b("baz")]);
+  //   });
+  // });
+  // describe("text()", () => {
+  //   it("maps output to string", function* () {
+  //     const stream = createSignal<Buffer, void>();
+  //     let ioStream = createOutputStream(stream);
+  //     let values: string[] = [];
+  //     yield* spawn(function* () {
+  //       for (const value of yield* each(ioStream.text())) {
+  //         values.push(value);
+  //         yield* each.next();
+  //       }
+  //     });
+  //     stream.send(b("foo"));
+  //     stream.send(b("bar"));
+  //     stream.send(b("baz"));
+  //     expect(values).toEqual(["foo", "bar", "baz"]);
+  //   });
+  // });
+  // describe("lines()", () => {
+  //   it("combines output into complete lines", function* () {
+  //     const stream = createSignal<Buffer, void>();
+  //     let ioStream = createOutputStream(stream);
+  //     let values: string[] = [];
+  //     yield* spawn(function* () {
+  //       for (const value of yield* each(ioStream.lines())) {
+  //         values.push(value);
+  //         yield* each.next();
+  //       }
+  //     });
+  //     stream.send(b("foo\nhello"));
+  //     stream.send(b("world\n"));
+  //     stream.send(b("something"));
+  //     stream.close();
+  //     expect(values).toEqual(["foo", "helloworld", "something"]);
+  //   });
+  // });
+});

--- a/process/tsconfig.json
+++ b/process/tsconfig.json
@@ -21,6 +21,9 @@
     },
     {
       "path": "../stream-helpers"
+    },
+    {
+      "path": "../vitest"
     }
   ]
 }

--- a/process/tsconfig.json
+++ b/process/tsconfig.json
@@ -8,16 +8,13 @@
   "exclude": ["**/*.test.ts", "test/**", "dist"],
   "references": [
     {
-      "path": "../scope-eval"
-    },
-    {
       "path": "../context-api"
     },
     {
-      "path": "../bdd"
+      "path": "../node"
     },
     {
-      "path": "../node"
+      "path": "../scope-eval"
     },
     {
       "path": "../stream-helpers"

--- a/raf/package.json
+++ b/raf/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "@essentials/raf": "^1",
     "effection": "^4"
   }

--- a/raf/raf.test.ts
+++ b/raf/raf.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import {
   caf as cancelAnimationFrame,
   raf as requestAnimationFrame,

--- a/raf/tsconfig.json
+++ b/raf/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/scope-eval/box.test.ts
+++ b/scope-eval/box.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { Err, Ok } from "effection";
 import { expect } from "expect";
 import { box, unbox } from "./mod.ts";

--- a/scope-eval/eval-scope.test.ts
+++ b/scope-eval/eval-scope.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { createContext } from "effection";
 import { expect } from "expect";
 import { unbox, useEvalScope } from "./mod.ts";

--- a/scope-eval/package.json
+++ b/scope-eval/package.json
@@ -29,7 +29,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/scope-eval/tsconfig.json
+++ b/scope-eval/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/signals/array.test.ts
+++ b/signals/array.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { race, sleep, spawn, withResolvers } from "effection";
 

--- a/signals/boolean.test.ts
+++ b/signals/boolean.test.ts
@@ -6,7 +6,7 @@ import {
   spawn,
   withResolvers,
 } from "effection";
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { createBooleanSignal } from "./boolean.ts";
 

--- a/signals/helpers.test.ts
+++ b/signals/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { sleep, spawn, withResolvers } from "effection";
 

--- a/signals/package.json
+++ b/signals/package.json
@@ -31,7 +31,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/signals/set.test.ts
+++ b/signals/set.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { each, spawn } from "effection";
 import { createSetSignal } from "./set.ts";

--- a/signals/tsconfig.json
+++ b/signals/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/stream-helpers/batch.test.ts
+++ b/stream-helpers/batch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { createArraySignal, is } from "@effectionx/signals";
 import { expect } from "expect";
 import { createChannel, sleep, spawn } from "effection";

--- a/stream-helpers/drain.test.ts
+++ b/stream-helpers/drain.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 
 import { drain } from "./drain.ts";

--- a/stream-helpers/filter.test.ts
+++ b/stream-helpers/filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { sleep } from "effection";
 

--- a/stream-helpers/first.test.ts
+++ b/stream-helpers/first.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 
 import { first } from "./first.ts";

--- a/stream-helpers/for-each.test.ts
+++ b/stream-helpers/for-each.test.ts
@@ -1,5 +1,5 @@
 import { createChannel, sleep, spawn } from "effection";
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 
 import { forEach } from "./for-each.ts";

--- a/stream-helpers/last.test.ts
+++ b/stream-helpers/last.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 
 import { last } from "./last.ts";

--- a/stream-helpers/map.test.ts
+++ b/stream-helpers/map.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { sleep } from "effection";
 

--- a/stream-helpers/package.json
+++ b/stream-helpers/package.json
@@ -40,7 +40,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/stream-helpers/reduce.test.ts
+++ b/stream-helpers/reduce.test.ts
@@ -1,5 +1,5 @@
 import { createChannel, type Operation, sleep, spawn } from "effection";
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 
 import { forEach } from "./for-each.ts";

--- a/stream-helpers/subject.test.ts
+++ b/stream-helpers/subject.test.ts
@@ -4,7 +4,7 @@ import {
   type Stream,
   type Subscription,
 } from "effection";
-import { beforeEach, describe, it } from "@effectionx/bdd";
+import { beforeEach, describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 
 import { createSubject } from "./subject.ts";

--- a/stream-helpers/take-until.test.ts
+++ b/stream-helpers/take-until.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { pipe } from "remeda";
 

--- a/stream-helpers/take-while.test.ts
+++ b/stream-helpers/take-while.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { pipe } from "remeda";
 

--- a/stream-helpers/take.test.ts
+++ b/stream-helpers/take.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { pipe } from "remeda";
 

--- a/stream-helpers/test-helpers/faucet.test.ts
+++ b/stream-helpers/test-helpers/faucet.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { createArraySignal, is } from "@effectionx/signals";
 import { expect } from "expect";
 import { each, race, sleep, spawn } from "effection";

--- a/stream-helpers/tracker.test.ts
+++ b/stream-helpers/tracker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { each, sleep, spawn } from "effection";
 import { pipe } from "remeda";

--- a/stream-helpers/tsconfig.json
+++ b/stream-helpers/tsconfig.json
@@ -8,13 +8,13 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
-    },
-    {
       "path": "../signals"
     },
     {
       "path": "../timebox"
+    },
+    {
+      "path": "../vitest"
     }
   ]
 }

--- a/stream-helpers/valve.test.ts
+++ b/stream-helpers/valve.test.ts
@@ -1,8 +1,8 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { createArraySignal, is } from "@effectionx/signals";
 import { expect } from "expect";
-import { mock } from "node:test";
 import { each, sleep, spawn } from "effection";
+import { vi } from "vitest";
 
 import { valve } from "./valve.ts";
 import { useFaucet } from "./test-helpers/faucet.ts";
@@ -14,12 +14,12 @@ describe("valve", () => {
     const closeFn = function* () {
       faucet.close();
     };
-    const close = mock.fn(closeFn);
+    const close = vi.fn(closeFn);
 
     const openFn = function* () {
       faucet.open();
     };
-    const open = mock.fn(openFn);
+    const open = vi.fn(openFn);
 
     const stream = valve({
       closeAt: 5,
@@ -46,7 +46,7 @@ describe("valve", () => {
 
     expect(values.valueOf()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-    expect(close.mock.callCount()).toBe(1);
-    expect(open.mock.callCount()).toBe(1);
+    expect(close.mock.calls.length).toBe(1);
+    expect(open.mock.calls.length).toBe(1);
   });
 });

--- a/stream-yaml/package.json
+++ b/stream-yaml/package.json
@@ -31,7 +31,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "@effectionx/stream-helpers": "workspace:*",
     "effection": "^4"
   }

--- a/stream-yaml/tsconfig.json
+++ b/stream-yaml/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/stream-yaml/yaml-documents.test.ts
+++ b/stream-yaml/yaml-documents.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { createChannel, spawn } from "effection";
 import { expect } from "expect";
 

--- a/task-buffer/package.json
+++ b/task-buffer/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "@sinonjs/fake-timers": "^14",
     "@types/sinonjs__fake-timers": "^8",
     "effection": "^4"

--- a/task-buffer/task-buffer.test.ts
+++ b/task-buffer/task-buffer.test.ts
@@ -1,6 +1,6 @@
 import FakeTimers from "@sinonjs/fake-timers";
 import { sleep, spawn, type Task, until } from "effection";
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { useTaskBuffer } from "./task-buffer.ts";
 

--- a/task-buffer/tsconfig.json
+++ b/task-buffer/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/test-adapter/mod.ts
+++ b/test-adapter/mod.ts
@@ -204,11 +204,24 @@ export function createTestAdapter(
       if (!adapterTask) {
         return Promise.resolve() as Future<void>;
       }
-      return adapterTask.halt().then(() => {
-        if (destroyRoot) {
-          return destroyRoot();
-        }
-      }) as Future<void>;
+      return adapterTask
+        .halt()
+        .catch((error) => {
+          if (error instanceof Error && error.message === "halted") {
+            return undefined;
+          }
+          throw error;
+        })
+        .then(() => {
+          if (destroyRoot) {
+            return destroyRoot().catch((error) => {
+              if (error instanceof Error && error.message === "halted") {
+                return undefined;
+              }
+              throw error;
+            });
+          }
+        }) as Future<void>;
     },
   };
 

--- a/test-adapter/mod.ts
+++ b/test-adapter/mod.ts
@@ -3,6 +3,7 @@ import type {
   Operation,
   Result,
   Scope,
+  Task,
   WithResolvers,
 } from "effection";
 import {
@@ -113,7 +114,8 @@ export function createTestAdapter(
   const { parent, name = anonymousNames.next().value } = options;
 
   let scope: WithResolvers<Result<Scope>> | undefined = undefined;
-  let destroy: () => Operation<void> = function* () {};
+  let adapterTask: Task<void> | undefined = undefined;
+  let destroyRoot: (() => Future<void>) | undefined = undefined;
 
   const adapter: TestAdapter = {
     parent,
@@ -167,7 +169,6 @@ export function createTestAdapter(
       scope = withResolvers<Result<Scope>>();
 
       let parent: Result<Scope>;
-      let destroyRoot: (() => Future<void>) | undefined = undefined;
       if (adapter.parent) {
         parent = yield* adapter.parent["@@init@@"]();
       } else {
@@ -195,16 +196,20 @@ export function createTestAdapter(
         }
       });
 
-      destroy = function* () {
-        yield* task.halt();
-        if (destroyRoot) {
-          yield* destroyRoot();
-        }
-      };
+      adapterTask = task;
 
       return yield* scope.operation;
     },
-    destroy: () => run(destroy),
+    destroy() {
+      if (!adapterTask) {
+        return Promise.resolve() as Future<void>;
+      }
+      return adapterTask.halt().then(() => {
+        if (destroyRoot) {
+          return destroyRoot();
+        }
+      }) as Future<void>;
+    },
   };
 
   return adapter;

--- a/test-adapter/test/adapter.test.ts
+++ b/test-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "expect";
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import { createContext, resource } from "effection";
 import { createTestAdapter } from "../mod.ts";
 

--- a/timebox/package.json
+++ b/timebox/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "effection": "^4"
   }
 }

--- a/timebox/timebox.test.ts
+++ b/timebox/timebox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
 import { timebox } from "./mod.ts";
 import { type Operation, sleep, suspend } from "effection";

--- a/timebox/tsconfig.json
+++ b/timebox/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     target: "es2022",
   },
   test: {
+    hookTimeout: 30000,
     include: ["**/*.test.ts"],
     exclude: [
       "**/dist/**",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,9 @@ export default defineConfig({
     hookTimeout: 30000,
     include: ["**/*.test.ts"],
     exclude: ["**/dist/**", "**/node_modules/**", "**/bdd/**"],
+    reporters:
+      process.env.GITHUB_ACTIONS === "true"
+        ? ["default", "github-actions"]
+        : ["default"],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    target: "es2022",
+  },
+  test: {
+    include: ["**/*.test.ts"],
+    exclude: [
+      "**/dist/**",
+      "**/node_modules/**",
+      "process/test/output-stream.test.ts",
+    ],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   test: {
     hookTimeout: 30000,
     include: ["**/*.test.ts"],
-    exclude: ["**/dist/**", "**/node_modules/**"],
+    exclude: ["**/dist/**", "**/node_modules/**", "**/bdd/**"],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,10 +7,6 @@ export default defineConfig({
   test: {
     hookTimeout: 30000,
     include: ["**/*.test.ts"],
-    exclude: [
-      "**/dist/**",
-      "**/node_modules/**",
-      "process/test/output-stream.test.ts",
-    ],
+    exclude: ["**/dist/**", "**/node_modules/**"],
   },
 });

--- a/vitest/package.json
+++ b/vitest/package.json
@@ -22,6 +22,8 @@
     "@effectionx/test-adapter": "workspace:*"
   },
   "devDependencies": {
+    "@types/cross-spawn": "^6",
+    "cross-spawn": "^7",
     "effection": "^4",
     "vitest": "^4"
   },

--- a/vitest/package.json
+++ b/vitest/package.json
@@ -22,8 +22,6 @@
     "@effectionx/test-adapter": "workspace:*"
   },
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
-    "@effectionx/process": "workspace:*",
     "effection": "^4",
     "vitest": "^4"
   },

--- a/vitest/tsconfig.json
+++ b/vitest/tsconfig.json
@@ -8,12 +8,6 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
-    },
-    {
-      "path": "../process"
-    },
-    {
       "path": "../test-adapter"
     }
   ]

--- a/vitest/vitest.test.ts
+++ b/vitest/vitest.test.ts
@@ -1,21 +1,25 @@
 import { describe, it } from "@effectionx/vitest";
+import spawn from "cross-spawn";
 import { expect } from "expect";
-import { spawnSync } from "node:child_process";
 
 function runVitest(args: string[]): {
   code: number | null;
   stdout: string;
   stderr: string;
 } {
-  const result = spawnSync("pnpm", ["vitest", "run", ...args], {
+  const result = spawn.sync("pnpm", ["vitest", "run", ...args], {
     cwd: import.meta.dirname,
     encoding: "utf8",
   });
 
+  const stderr = [result.error?.message ?? "", result.stderr ?? ""]
+    .filter(Boolean)
+    .join("\n");
+
   return {
     code: result.status,
     stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
+    stderr,
   };
 }
 

--- a/vitest/vitest.test.ts
+++ b/vitest/vitest.test.ts
@@ -1,15 +1,30 @@
-import { describe, it } from "@effectionx/bdd";
-import { exec } from "@effectionx/process";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
+import { spawnSync } from "node:child_process";
+
+function runVitest(args: string[]): {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+} {
+  const result = spawnSync("pnpm", ["vitest", "run", ...args], {
+    cwd: import.meta.dirname,
+    encoding: "utf8",
+  });
+
+  return {
+    code: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
 
 describe("@effectionx/vitest", () => {
   it("runs vitest tests with effection operations", function* () {
-    let result = yield* exec(
-      "pnpm vitest run test/fixtures/sample.vitest.ts --reporter=verbose",
-      {
-        cwd: import.meta.dirname,
-      },
-    ).join();
+    const result = runVitest([
+      "test/fixtures/sample.vitest.ts",
+      "--reporter=verbose",
+    ]);
 
     // Verify exit code
     expect(result.code).toEqual(0);
@@ -29,12 +44,10 @@ describe("@effectionx/vitest", () => {
   });
 
   it("correctly scopes adapters across nested describes", function* () {
-    let result = yield* exec(
-      "pnpm vitest run test/fixtures/nested-scopes.vitest.ts --reporter=verbose",
-      {
-        cwd: import.meta.dirname,
-      },
-    ).join();
+    const result = runVitest([
+      "test/fixtures/nested-scopes.vitest.ts",
+      "--reporter=verbose",
+    ]);
 
     expect(result.code).toEqual(0);
 
@@ -49,12 +62,11 @@ describe("@effectionx/vitest", () => {
   });
 
   it("isolates scopes across multiple test files", function* () {
-    let result = yield* exec(
-      "pnpm vitest run test/fixtures/sample.vitest.ts test/fixtures/nested-scopes.vitest.ts --reporter=verbose",
-      {
-        cwd: import.meta.dirname,
-      },
-    ).join();
+    const result = runVitest([
+      "test/fixtures/sample.vitest.ts",
+      "test/fixtures/nested-scopes.vitest.ts",
+      "--reporter=verbose",
+    ]);
 
     expect(result.code).toEqual(0);
 
@@ -63,12 +75,10 @@ describe("@effectionx/vitest", () => {
   });
 
   it("reports failing tests correctly", function* () {
-    let result = yield* exec(
-      "pnpm vitest run test/fixtures/failing.vitest.ts --reporter=verbose",
-      {
-        cwd: import.meta.dirname,
-      },
-    ).join();
+    const result = runVitest([
+      "test/fixtures/failing.vitest.ts",
+      "--reporter=verbose",
+    ]);
 
     // Verify exit code is non-zero (tests failed)
     expect(result.code).not.toEqual(0);

--- a/watch/package.json
+++ b/watch/package.json
@@ -43,7 +43,7 @@
     "@effectionx/fs": "workspace:*"
   },
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "@effectionx/signals": "workspace:*",
     "@effectionx/stream-helpers": "workspace:*",
     "effection": "^4"

--- a/watch/test/watch.test.ts
+++ b/watch/test/watch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { createArraySignal, is } from "@effectionx/signals";
 import { forEach } from "@effectionx/stream-helpers";
 import { expect } from "expect";

--- a/watch/tsconfig.json
+++ b/watch/tsconfig.json
@@ -9,9 +9,6 @@
   "exclude": ["**/*.test.ts", "test/**", "dist"],
   "references": [
     {
-      "path": "../bdd"
-    },
-    {
       "path": "../fs"
     },
     {
@@ -22,6 +19,9 @@
     },
     {
       "path": "../stream-helpers"
+    },
+    {
+      "path": "../vitest"
     }
   ]
 }

--- a/websocket/package.json
+++ b/websocket/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "@types/ws": "^8",
     "effection": "^4",
     "ws": "^8"

--- a/websocket/tsconfig.json
+++ b/websocket/tsconfig.json
@@ -8,7 +8,7 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
-      "path": "../bdd"
+      "path": "../vitest"
     }
   ]
 }

--- a/websocket/websocket.test.ts
+++ b/websocket/websocket.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import {
   type Operation,
   type Subscription,

--- a/worker/channel.test.ts
+++ b/worker/channel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effectionx/bdd";
+import { describe, it } from "@effectionx/vitest";
 import { timebox } from "@effectionx/timebox";
 import { once, race, sleep, spawn, suspend, withResolvers } from "effection";
 import { expect } from "expect";

--- a/worker/package.json
+++ b/worker/package.json
@@ -33,7 +33,7 @@
     "web-worker": "^1"
   },
   "devDependencies": {
-    "@effectionx/bdd": "workspace:*",
+    "@effectionx/vitest": "workspace:*",
     "@effectionx/converge": "workspace:*",
     "effection": "^4"
   }

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -8,9 +8,6 @@
   "exclude": ["**/*.test.ts", "test-assets/**", "dist"],
   "references": [
     {
-      "path": "../bdd"
-    },
-    {
       "path": "../converge"
     },
     {
@@ -18,6 +15,9 @@
     },
     {
       "path": "../timebox"
+    },
+    {
+      "path": "../vitest"
     }
   ]
 }

--- a/worker/worker.test.ts
+++ b/worker/worker.test.ts
@@ -1,7 +1,7 @@
 import { access, mkdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { beforeEach, describe, it } from "@effectionx/bdd";
+import { beforeEach, describe, it } from "@effectionx/vitest";
 import { when } from "@effectionx/converge";
 import {
   all,


### PR DESCRIPTION
# Motivation

The TAP output from all of the node tests was difficult to read. We are exploring switching to vitest for better ergonomics, both locally and in CI.

# Approach

- Swap to our vitest packag
- deal with circular refs
- update test matrix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migrated test runner from custom TAP-based framework to Vitest with JSON reporting
  * Added GitHub Actions-aware test output formatting
  * Enhanced test matrix reporting with skip counts and pass rates

* **Improvements**
  * Improved failure detection and reporting in test matrices
  * Added aggregate test statistics (passed/failed/skipped) to summary tables
<!-- end of auto-generated comment: release notes by coderabbit.ai -->