### PR TITLE
✨ Export MiddlewareSlot utility type from context-api

### DIFF
--- a/context-api/mod.ts
+++ b/context-api/mod.ts
@@ -15,6 +15,15 @@ export type Around<A> = {
     : Middleware<[], A[K]>;
 };
 
+/**
+ * The middleware type for a single operation slot in an {@link Api}.
+ *
+ * Use this to type helper functions that accept or return middleware
+ * for a specific key of an API without reconstructing the mapping
+ * from {@link Around} by hand.
+ */
+export type MiddlewareSlot<A, K extends keyof A> = Around<A>[K];
+
 export interface Api<A> {
   operations: Operations<A>;
   around: (

--- a/context-api/mod.ts
+++ b/context-api/mod.ts
@@ -4,25 +4,27 @@ import { type Operation, type Scope, createContext, useScope } from "effection";
 export type { Middleware };
 
 /**
- * The shape of middlewares that can surround a particular {@link Api}.
+ * The middleware type for a single property of an {@link Api}.
  *
- * Members that are functions get middleware matching their signature.
- * Members that are values get middleware wrapping a no-arg accessor.
- */
-export type Around<A> = {
-  [K in keyof A]: A[K] extends (...args: infer TArgs) => infer TReturn
-    ? Middleware<TArgs, TReturn>
-    : Middleware<[], A[K]>;
-};
-
-/**
- * The middleware type for a single operation slot in an {@link Api}.
+ * Function members get middleware matching their signature.
+ * Value members get middleware wrapping a no-arg accessor.
  *
  * Use this to type helper functions that accept or return middleware
  * for a specific key of an API without reconstructing the mapping
  * from {@link Around} by hand.
  */
-export type MiddlewareSlot<A, K extends keyof A> = Around<A>[K];
+export type PropertyMiddleware<A, K extends keyof A> = A[K] extends (
+  ...args: infer TArgs
+) => infer TReturn
+  ? Middleware<TArgs, TReturn>
+  : Middleware<[], A[K]>;
+
+/**
+ * The shape of middlewares that can surround a particular {@link Api}.
+ */
+export type Around<A> = {
+  [K in keyof A]: PropertyMiddleware<A, K>;
+};
 
 export interface Api<A> {
   operations: Operations<A>;

--- a/context-api/package.json
+++ b/context-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/context-api",
   "description": "Algebraic effects pattern for context-dependent operations with middleware",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "keywords": ["concurrency", "interop"],
   "type": "module",
   "main": "./dist/mod.js",


### PR DESCRIPTION
# Motivation

The `Around<A>` mapped type defines how each API member maps to its middleware signature, but there is no public type to extract the middleware type for a *single* slot. Writing generic middleware helpers today requires duplicating the conditional-type logic from `Around<A>`, which is fragile — if the mapping changes, hand-rolled extractions silently drift.

# Approach

Export `MiddlewareSlot<A, K>` — a type alias defined as `Around<A>[K]`. This gives the slot type a stable public name at zero runtime cost, so typed helpers can reference it directly instead of reconstructing the mapping by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a developer-facing type convenience to simplify middleware slot configuration for individual API operations.
* **Chores**
  * Bumped package version to 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->