### PR TITLE
✨ feat(node): add Stdio context API for host process stdio

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -19,10 +19,11 @@ This package provides two sub-modules:
 - `@effectionx/node/stream` - Stream utilities for Node.js
 - `@effectionx/node/events` - Event utilities for Node.js EventEmitters
 
-You can also import everything from the main module:
+You can also import everything — including the `Stdio` context API —
+from the main module:
 
 ```typescript
-import { fromReadable, on, once } from "@effectionx/node";
+import { Stdio, fromReadable, on, once, stdin, stdout } from "@effectionx/node";
 ```
 
 ## Stream Utilities
@@ -48,6 +49,123 @@ await main(function* () {
 
 The returned stream emits `Uint8Array` chunks and automatically cleans up
 event listeners when the stream is closed or the operation is shut down.
+
+## Host Stdio
+
+`Stdio` is a middleware-capable context API for the **host** process's
+standard input, output, and error streams. The default handlers read
+from `process.stdin` and write to `process.stdout` / `process.stderr`,
+so in normal production code you just call the operations and bytes
+flow as you'd expect. Install middleware with `Stdio.around({ ... })`
+inside any scope to observe, transform, or redirect those bytes — useful
+for tests that assert what a program wrote to stdout, or harnesses that
+feed synthesized input to code reading from stdin.
+
+This is distinct from `@effectionx/process`'s `Stdio`, which governs
+**child**-process stdio.
+
+### Writing to stdout / stderr
+
+`stdout` and `stderr` are `(bytes: Uint8Array) => Operation<void>`
+operations destructured from `Stdio.operations` and re-exported at the
+package root, so you can use them directly:
+
+```typescript
+import { main } from "effection";
+import { stderr, stdout } from "@effectionx/node";
+
+await main(function* () {
+  yield* stdout(new TextEncoder().encode("hello\n"));
+  yield* stderr(new TextEncoder().encode("oops\n"));
+});
+```
+
+### Reading stdin
+
+`stdin()` returns a `Stream<Uint8Array, void>` sourced from
+`process.stdin`. A single `yield*` gives you a subscription you can
+iterate, or use `each` for a `for`-loop:
+
+```typescript
+import { each, main } from "effection";
+import { stdin, stdout } from "@effectionx/node";
+
+await main(function* () {
+  // echo every chunk back to stdout
+  for (const chunk of yield* each(stdin())) {
+    yield* stdout(chunk);
+    yield* each.next();
+  }
+});
+```
+
+### Intercepting with middleware
+
+Middleware is registered per scope via `Stdio.around(...)`. Each member
+is a function `(args, next) => TReturn` where delegation to the next
+link (including the default handler) is `next(...args)`. Middleware
+applies to the current scope and its descendants until they exit.
+
+```typescript
+import { main } from "effection";
+import { Stdio, stdout } from "@effectionx/node";
+
+await main(function* () {
+  const captured: Uint8Array[] = [];
+
+  yield* Stdio.around({
+    *stdout(args, next) {
+      captured.push(args[0]);
+      return yield* next(...args); // delegate so bytes still reach process.stdout
+    },
+  });
+
+  yield* stdout(new TextEncoder().encode("hello\n"));
+  // `captured` holds the bytes, and they also reached the terminal
+});
+```
+
+To **redirect** without reaching the default handler, simply don't call
+`next`:
+
+```typescript
+yield* Stdio.around({
+  *stdout(args, _next) {
+    captured.push(args[0]);
+    // no call to next → nothing is written to process.stdout
+  },
+});
+```
+
+### Substituting stdin
+
+Because `stdin()` returns a `Stream` directly, a `stdin` middleware is
+a plain function that returns a replacement stream — useful for
+feeding a synthetic input sequence from a test:
+
+```typescript
+import { createSignal, each, main } from "effection";
+import { Stdio, stdin } from "@effectionx/node";
+
+await main(function* () {
+  const signal = createSignal<Uint8Array, void>();
+
+  yield* Stdio.around({
+    stdin(_args, _next) {
+      return signal;
+    },
+  });
+
+  // From elsewhere in your test, drive the stream:
+  //   signal.send(new TextEncoder().encode("line 1\n"));
+  //   signal.close();
+
+  for (const chunk of yield* each(stdin())) {
+    // ...handle synthesized input
+    yield* each.next();
+  }
+});
+```
 
 ## Event Utilities
 

--- a/node/mod.ts
+++ b/node/mod.ts
@@ -1,2 +1,3 @@
 export * from "./stream.ts";
 export * from "./events.ts";
+export * from "./stdio.ts";

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/node",
   "description": "Node.js stream and event emitter adapters for Effection",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "keywords": ["io", "streams"],
   "type": "module",
   "main": "./dist/mod.js",
@@ -25,6 +25,9 @@
       "import": "./dist/events.js",
       "default": "./dist/events.js"
     }
+  },
+  "dependencies": {
+    "@effectionx/context-api": "workspace:*"
   },
   "peerDependencies": {
     "effection": "^3 || ^4"

--- a/node/stdio.test.ts
+++ b/node/stdio.test.ts
@@ -84,13 +84,12 @@ describe("Stdio middleware", () => {
     const synthetic: Stream<Uint8Array, void> = signal;
 
     yield* Stdio.around({
-      *stdin(_args, _next) {
+      stdin(_args, _next) {
         return synthetic;
       },
     });
 
-    const stream = yield* stdin();
-    const subscription = yield* stream;
+    const subscription = yield* stdin();
 
     const encoder = new TextEncoder();
     signal.send(encoder.encode("one"));
@@ -161,8 +160,7 @@ describe("Stdio defaults", () => {
     const original = overrideStdio("stdin", fake);
 
     try {
-      const stream = yield* stdin();
-      const subscription = yield* stream;
+      const subscription = yield* stdin();
 
       fake.write(Buffer.from("hello\n"));
       fake.end();

--- a/node/stdio.test.ts
+++ b/node/stdio.test.ts
@@ -1,47 +1,85 @@
 import process from "node:process";
-import { PassThrough } from "node:stream";
+import { PassThrough, Writable } from "node:stream";
 import { describe, it } from "@effectionx/vitest";
 import { createSignal, scoped, type Stream } from "effection";
 import { expect } from "expect";
 
 import { Stdio, stderr, stdin, stdout } from "./stdio.ts";
 
+function captureWritable(): { stream: Writable; written: Uint8Array[] } {
+  const written: Uint8Array[] = [];
+  const stream = new Writable({
+    write(chunk: Uint8Array, _enc, cb) {
+      written.push(chunk);
+      cb();
+    },
+  });
+  return { stream, written };
+}
+
+function overrideStdio(
+  key: "stdin" | "stdout" | "stderr",
+  value: unknown,
+): PropertyDescriptor {
+  const original = Object.getOwnPropertyDescriptor(process, key)!;
+  Object.defineProperty(process, key, { configurable: true, value });
+  return original;
+}
+
 describe("Stdio middleware", () => {
-  it("captures stdout bytes via middleware", function* () {
-    const captured: Uint8Array[] = [];
+  it("captures stdout bytes via middleware and delegates to process.stdout", function* () {
+    const { stream: fakeStdout, written } = captureWritable();
+    const original = overrideStdio("stdout", fakeStdout);
 
-    yield* Stdio.around({
-      *stdout(args, next) {
-        captured.push(args[0]);
-        return yield* next(...args);
-      },
-    });
+    try {
+      const captured: Uint8Array[] = [];
+      yield* Stdio.around({
+        *stdout(args, next) {
+          captured.push(args[0]);
+          return yield* next(...args);
+        },
+      });
 
-    const bytes = new TextEncoder().encode("hello\n");
-    yield* stdout(bytes);
+      const bytes = new TextEncoder().encode("hello\n");
+      yield* stdout(bytes);
 
-    expect(captured.length).toBe(1);
-    expect(new TextDecoder().decode(captured[0])).toBe("hello\n");
+      const decoder = new TextDecoder();
+      expect(captured.length).toBe(1);
+      expect(decoder.decode(captured[0])).toBe("hello\n");
+      expect(written.length).toBe(1);
+      expect(decoder.decode(written[0])).toBe("hello\n");
+    } finally {
+      Object.defineProperty(process, "stdout", original);
+    }
   });
 
-  it("captures stderr bytes via middleware", function* () {
-    const captured: Uint8Array[] = [];
+  it("captures stderr bytes via middleware and delegates to process.stderr", function* () {
+    const { stream: fakeStderr, written } = captureWritable();
+    const original = overrideStdio("stderr", fakeStderr);
 
-    yield* Stdio.around({
-      *stderr(args, next) {
-        captured.push(args[0]);
-        return yield* next(...args);
-      },
-    });
+    try {
+      const captured: Uint8Array[] = [];
+      yield* Stdio.around({
+        *stderr(args, next) {
+          captured.push(args[0]);
+          return yield* next(...args);
+        },
+      });
 
-    const bytes = new TextEncoder().encode("oops\n");
-    yield* stderr(bytes);
+      const bytes = new TextEncoder().encode("oops\n");
+      yield* stderr(bytes);
 
-    expect(captured.length).toBe(1);
-    expect(new TextDecoder().decode(captured[0])).toBe("oops\n");
+      const decoder = new TextDecoder();
+      expect(captured.length).toBe(1);
+      expect(decoder.decode(captured[0])).toBe("oops\n");
+      expect(written.length).toBe(1);
+      expect(decoder.decode(written[0])).toBe("oops\n");
+    } finally {
+      Object.defineProperty(process, "stderr", original);
+    }
   });
 
-  it("can substitute stdin with a synthetic stream", function* () {
+  it("can substitute stdin with a synthetic stream and propagates completion", function* () {
     const signal = createSignal<Uint8Array, void>();
     const synthetic: Stream<Uint8Array, void> = signal;
 
@@ -59,61 +97,68 @@ describe("Stdio middleware", () => {
     signal.send(encoder.encode("two"));
     signal.close();
 
-    const chunks: string[] = [];
     const decoder = new TextDecoder();
-    let result = yield* subscription.next();
-    while (!result.done) {
-      chunks.push(decoder.decode(result.value));
-      result = yield* subscription.next();
-    }
 
-    expect(chunks).toEqual(["one", "two"]);
+    let result = yield* subscription.next();
+    if (result.done) {
+      throw new Error("expected first chunk before end-of-stream");
+    }
+    expect(decoder.decode(result.value)).toBe("one");
+
+    result = yield* subscription.next();
+    if (result.done) {
+      throw new Error("expected second chunk before end-of-stream");
+    }
+    expect(decoder.decode(result.value)).toBe("two");
+
+    result = yield* subscription.next();
+    expect(result.done).toBe(true);
   });
 
   it("middleware is scoped and does not leak", function* () {
-    const outerCalls: string[] = [];
+    const { stream: fakeStdout } = captureWritable();
+    const original = overrideStdio("stdout", fakeStdout);
 
-    yield* Stdio.around({
-      *stdout(args, next) {
-        outerCalls.push("outer");
-        return yield* next(...args);
-      },
-    });
-
-    const bytes = new TextEncoder().encode("hi\n");
-    yield* stdout(bytes);
-    expect(outerCalls).toEqual(["outer"]);
-
-    yield* scoped(function* () {
-      const innerCalls: string[] = [];
-
+    try {
+      const outerCalls: string[] = [];
       yield* Stdio.around({
         *stdout(args, next) {
-          innerCalls.push("inner");
+          outerCalls.push("outer");
           return yield* next(...args);
         },
       });
 
+      const bytes = new TextEncoder().encode("hi\n");
       yield* stdout(bytes);
-      expect(outerCalls).toEqual(["outer", "outer"]);
-      expect(innerCalls).toEqual(["inner"]);
-    });
+      expect(outerCalls).toEqual(["outer"]);
 
-    outerCalls.length = 0;
-    yield* stdout(bytes);
-    expect(outerCalls).toEqual(["outer"]);
+      yield* scoped(function* () {
+        const innerCalls: string[] = [];
+        yield* Stdio.around({
+          *stdout(args, next) {
+            innerCalls.push("inner");
+            return yield* next(...args);
+          },
+        });
+
+        yield* stdout(bytes);
+        expect(outerCalls).toEqual(["outer", "outer"]);
+        expect(innerCalls).toEqual(["inner"]);
+      });
+
+      outerCalls.length = 0;
+      yield* stdout(bytes);
+      expect(outerCalls).toEqual(["outer"]);
+    } finally {
+      Object.defineProperty(process, "stdout", original);
+    }
   });
 });
 
 describe("Stdio defaults", () => {
   it("reads bytes from process.stdin by default", function* () {
-    const original = Object.getOwnPropertyDescriptor(process, "stdin")!;
     const fake = new PassThrough();
-
-    Object.defineProperty(process, "stdin", {
-      configurable: true,
-      value: fake,
-    });
+    const original = overrideStdio("stdin", fake);
 
     try {
       const stream = yield* stdin();

--- a/node/stdio.test.ts
+++ b/node/stdio.test.ts
@@ -1,7 +1,12 @@
 import process from "node:process";
 import { PassThrough, Writable } from "node:stream";
 import { describe, it } from "@effectionx/vitest";
-import { createSignal, scoped, type Stream } from "effection";
+import {
+  createSignal,
+  scoped,
+  type Stream,
+  type Subscription,
+} from "effection";
 import { expect } from "expect";
 
 import { Stdio, stderr, stdin, stdout } from "./stdio.ts";
@@ -24,6 +29,17 @@ function overrideStdio(
   const original = Object.getOwnPropertyDescriptor(process, key)!;
   Object.defineProperty(process, key, { configurable: true, value });
   return original;
+}
+
+function* drain(subscription: Subscription<Uint8Array, void>) {
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let r = yield* subscription.next();
+  while (!r.done) {
+    chunks.push(decoder.decode(r.value));
+    r = yield* subscription.next();
+  }
+  return chunks;
 }
 
 describe("Stdio middleware", () => {
@@ -175,6 +191,28 @@ describe("Stdio defaults", () => {
 
       result = yield* subscription.next();
       expect(result.done).toBe(true);
+    } finally {
+      Object.defineProperty(process, "stdin", original);
+    }
+  });
+
+  it("supports multiple concurrent stdin() consumers", function* () {
+    const fake = new PassThrough();
+    const original = overrideStdio("stdin", fake);
+
+    try {
+      const left = yield* stdin();
+      const right = yield* stdin();
+
+      fake.write(Buffer.from("one"));
+      fake.write(Buffer.from("two"));
+      fake.end();
+
+      const leftChunks = yield* drain(left);
+      const rightChunks = yield* drain(right);
+
+      expect(leftChunks).toEqual(["one", "two"]);
+      expect(rightChunks).toEqual(["one", "two"]);
     } finally {
       Object.defineProperty(process, "stdin", original);
     }

--- a/node/stdio.test.ts
+++ b/node/stdio.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from "@effectionx/vitest";
+import { createSignal, each, scoped, type Stream } from "effection";
+import { expect } from "expect";
+
+import { Stdio, stderr, stdin, stdout } from "./stdio.ts";
+
+describe("Stdio middleware", () => {
+  it("captures stdout bytes via middleware", function* () {
+    const captured: Uint8Array[] = [];
+
+    yield* Stdio.around({
+      *stdout(args, next) {
+        captured.push(args[0]);
+        return yield* next(...args);
+      },
+    });
+
+    const bytes = new TextEncoder().encode("hello\n");
+    yield* stdout(bytes);
+
+    expect(captured.length).toBe(1);
+    expect(new TextDecoder().decode(captured[0])).toBe("hello\n");
+  });
+
+  it("captures stderr bytes via middleware", function* () {
+    const captured: Uint8Array[] = [];
+
+    yield* Stdio.around({
+      *stderr(args, next) {
+        captured.push(args[0]);
+        return yield* next(...args);
+      },
+    });
+
+    const bytes = new TextEncoder().encode("oops\n");
+    yield* stderr(bytes);
+
+    expect(captured.length).toBe(1);
+    expect(new TextDecoder().decode(captured[0])).toBe("oops\n");
+  });
+
+  it("can substitute stdin with a synthetic stream", function* () {
+    const signal = createSignal<Uint8Array, void>();
+    const synthetic: Stream<Uint8Array, void> = signal;
+
+    yield* Stdio.around({
+      *stdin(_args, _next) {
+        return synthetic;
+      },
+    });
+
+    const stream = yield* stdin();
+    const subscription = yield* stream;
+
+    const encoder = new TextEncoder();
+    signal.send(encoder.encode("one"));
+    signal.send(encoder.encode("two"));
+    signal.close();
+
+    const chunks: string[] = [];
+    const decoder = new TextDecoder();
+    let result = yield* subscription.next();
+    while (!result.done) {
+      chunks.push(decoder.decode(result.value));
+      result = yield* subscription.next();
+    }
+
+    expect(chunks).toEqual(["one", "two"]);
+  });
+
+  it("middleware is scoped and does not leak", function* () {
+    const outerCalls: string[] = [];
+
+    yield* Stdio.around({
+      *stdout(args, next) {
+        outerCalls.push("outer");
+        return yield* next(...args);
+      },
+    });
+
+    const bytes = new TextEncoder().encode("hi\n");
+    yield* stdout(bytes);
+    expect(outerCalls).toEqual(["outer"]);
+
+    yield* scoped(function* () {
+      const innerCalls: string[] = [];
+
+      yield* Stdio.around({
+        *stdout(args, next) {
+          innerCalls.push("inner");
+          return yield* next(...args);
+        },
+      });
+
+      yield* stdout(bytes);
+      expect(outerCalls).toEqual(["outer", "outer"]);
+      expect(innerCalls).toEqual(["inner"]);
+    });
+
+    outerCalls.length = 0;
+    yield* stdout(bytes);
+    expect(outerCalls).toEqual(["outer"]);
+  });
+});
+
+describe("Stdio defaults", () => {
+  it("reads from process.stdin by default (subscription acquires without error)", function* () {
+    yield* scoped(function* () {
+      // Default handler wraps process.stdin via fromReadable. We just
+      // verify that acquiring a subscription and then letting the scope
+      // tear it down does not throw; we can't easily assert on real
+      // host stdin bytes in a unit test.
+      const stream = yield* stdin();
+      const _sub = yield* stream;
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/node/stdio.test.ts
+++ b/node/stdio.test.ts
@@ -1,5 +1,7 @@
+import process from "node:process";
+import { PassThrough } from "node:stream";
 import { describe, it } from "@effectionx/vitest";
-import { createSignal, each, scoped, type Stream } from "effection";
+import { createSignal, scoped, type Stream } from "effection";
 import { expect } from "expect";
 
 import { Stdio, stderr, stdin, stdout } from "./stdio.ts";
@@ -104,15 +106,34 @@ describe("Stdio middleware", () => {
 });
 
 describe("Stdio defaults", () => {
-  it("reads from process.stdin by default (subscription acquires without error)", function* () {
-    yield* scoped(function* () {
-      // Default handler wraps process.stdin via fromReadable. We just
-      // verify that acquiring a subscription and then letting the scope
-      // tear it down does not throw; we can't easily assert on real
-      // host stdin bytes in a unit test.
-      const stream = yield* stdin();
-      const _sub = yield* stream;
-      expect(true).toBe(true);
+  it("reads bytes from process.stdin by default", function* () {
+    const original = Object.getOwnPropertyDescriptor(process, "stdin")!;
+    const fake = new PassThrough();
+
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: fake,
     });
+
+    try {
+      const stream = yield* stdin();
+      const subscription = yield* stream;
+
+      fake.write(Buffer.from("hello\n"));
+      fake.end();
+
+      const decoder = new TextDecoder();
+
+      let result = yield* subscription.next();
+      if (result.done) {
+        throw new Error("expected a chunk before end-of-stream");
+      }
+      expect(decoder.decode(result.value)).toBe("hello\n");
+
+      result = yield* subscription.next();
+      expect(result.done).toBe(true);
+    } finally {
+      Object.defineProperty(process, "stdin", original);
+    }
   });
 });

--- a/node/stdio.ts
+++ b/node/stdio.ts
@@ -44,7 +44,7 @@ export interface StdioApi {
  *   });
  *
  *   yield* stdout(new TextEncoder().encode("hello\n"));
- *   // bytes flow into `captured` instead of the terminal
+ *   // bytes flow into `captured` and then on to the terminal
  * });
  * ```
  */

--- a/node/stdio.ts
+++ b/node/stdio.ts
@@ -11,7 +11,7 @@ import { fromReadable } from "./stream.ts";
  * corresponding output streams.
  */
 export interface StdioApi {
-  stdin(): Operation<Stream<Uint8Array, void>>;
+  stdin(): Stream<Uint8Array, void>;
   stdout(bytes: Uint8Array): Operation<void>;
   stderr(bytes: Uint8Array): Operation<void>;
 }
@@ -51,7 +51,7 @@ export interface StdioApi {
 export const Stdio: Api<StdioApi> = createApi<StdioApi>(
   "@effectionx/node/stdio",
   {
-    *stdin() {
+    stdin() {
       return fromReadable(process.stdin);
     },
     *stdout(bytes) {

--- a/node/stdio.ts
+++ b/node/stdio.ts
@@ -1,0 +1,66 @@
+import process from "node:process";
+import { type Api, createApi } from "@effectionx/context-api";
+import type { Operation, Stream } from "effection";
+import { fromReadable } from "./stream.ts";
+
+/**
+ * Middleware-capable shape for host-process stdio.
+ *
+ * `stdin` yields a readable byte stream sourced from the host's standard
+ * input. `stdout` and `stderr` take bytes and write them to the host's
+ * corresponding output streams.
+ */
+export interface StdioApi {
+  stdin(): Operation<Stream<Uint8Array, void>>;
+  stdout(bytes: Uint8Array): Operation<void>;
+  stderr(bytes: Uint8Array): Operation<void>;
+}
+
+/**
+ * Context API used to observe or customize the host process's stdio.
+ *
+ * By default, `stdin` reads from `process.stdin`, and `stdout` / `stderr`
+ * write to `process.stdout` / `process.stderr`. Middleware can wrap this API
+ * via `Stdio.around(...)` to capture, transform, or redirect bytes — useful
+ * for tests that assert what was written to stdout, or harnesses that feed
+ * synthesized stdin.
+ *
+ * This is distinct from `@effectionx/process`'s `Stdio`, which governs child
+ * process stdio.
+ *
+ * @example
+ * ```ts
+ * import { main } from "effection";
+ * import { Stdio, stdout } from "@effectionx/node";
+ *
+ * await main(function* () {
+ *   const captured: Uint8Array[] = [];
+ *
+ *   yield* Stdio.around({
+ *     *stdout(args, next) {
+ *       captured.push(args[0]);
+ *       return yield* next(...args);
+ *     },
+ *   });
+ *
+ *   yield* stdout(new TextEncoder().encode("hello\n"));
+ *   // bytes flow into `captured` instead of the terminal
+ * });
+ * ```
+ */
+export const Stdio: Api<StdioApi> = createApi<StdioApi>(
+  "@effectionx/node/stdio",
+  {
+    *stdin() {
+      return fromReadable(process.stdin);
+    },
+    *stdout(bytes) {
+      process.stdout.write(bytes);
+    },
+    *stderr(bytes) {
+      process.stderr.write(bytes);
+    },
+  },
+);
+
+export const { stdin, stdout, stderr } = Stdio.operations;

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -9,6 +9,9 @@
   "references": [
     {
       "path": "../vitest"
+    },
+    {
+      "path": "../context-api"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,10 @@ importers:
         version: link:../vitest
 
   node:
+    dependencies:
+      '@effectionx/context-api':
+        specifier: workspace:*
+        version: link:../context-api
     devDependencies:
       '@effectionx/vitest':
         specifier: workspace:*


### PR DESCRIPTION
# Motivation

Node-facing code in this repo has no programmable seam for the host process's `stdin`, `stdout`, and `stderr`. Tests that want to assert what was written to stdout must reach for ad-hoc spies, and harnesses that want to feed synthesized stdin to code under test have no clean way to do so.

`@effectionx/process` already ships a `Stdio` context API, but that one governs **child**-process stdio — a different concern. Using it for host stdio conflated two scopes and was part of why an earlier attempt (in #159) at moving Stdio around had to be reverted.

This PR introduces a dedicated, middleware-capable `Stdio` context API that lives in `@effectionx/node` and is solely about the **host** process's stdio.

# Approach

- New `Stdio` context API at `@effectionx/node` with scope `"@effectionx/node/stdio"`, exposing three operations:
  - `stdin()` — returns a `Stream<Uint8Array, void>` sourced from `process.stdin` via the existing `fromReadable` helper.
  - `stdout(bytes)` — writes to `process.stdout`.
  - `stderr(bytes)` — writes to `process.stderr`.
- `stdin`, `stdout`, and `stderr` are destructured from `Stdio.operations` and re-exported so callers can `yield* stdout(bytes)` directly, matching the ergonomics of `@effectionx/fs`.
- Middleware is installed with `Stdio.around({ *stdout(args, next) { ... return yield* next(...args); } })` per the repo's `(args, next)` / `next(...args)` contract.
- The child-process `Stdio` in `@effectionx/process` (scope `@effectionx/process:io`) is **unchanged**. The two APIs coexist — different packages, different scope names, no context-registry collision.
- `@effectionx/context-api` is added as a runtime `dependency` of `@effectionx/node`.
- `node/tsconfig.json` gains a reference to `../context-api`.
- Package version bumps `0.2.4 → 0.3.0` for the new public API surface.

## Usage

```ts
import { main } from "effection";
import { Stdio, stdout } from "@effectionx/node";

await main(function* () {
  const captured: Uint8Array[] = [];

  yield* Stdio.around({
    *stdout(args, next) {
      captured.push(args[0]);
      return yield* next(...args);
    },
  });

  yield* stdout(new TextEncoder().encode("hello\n"));
  // bytes land in `captured` instead of the terminal
});
```

## Tests

`node/stdio.test.ts` covers: stdout capture via middleware, stderr capture, stdin substitution with a synthetic stream, scope isolation (inner middleware does not leak to the outer scope), and a default-handler smoke test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Stdio context API for reading stdin and writing to stdout/stderr in Node.js
  * Public module exports expanded to expose stdio functionality

* **Tests**
  * Added comprehensive tests covering Stdio middleware, stream operations, and scoping

* **Documentation**
  * Updated docs with examples for host stdio usage, middleware interception, and stdin substitution

* **Chores**
  * Package version bumped and manifest updated to include a new dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->