### PR TITLE
✨ feat(context-api): user-defined middleware groups

### DIFF
--- a/context-api/README.md
+++ b/context-api/README.md
@@ -61,8 +61,17 @@ the scope exits, the middleware is removed.
 
 ## Min/Max Priority
 
-By default, `around()` registers middleware at `"max"` priority (outermost,
-closest to the caller). You can also register at `"min"` priority (innermost,
+By default, `createApi()` configures two middleware groups:
+
+```ts
+[
+  { name: "max", mode: "append" },
+  { name: "min", mode: "prepend" },
+]
+```
+
+`around()` registers into `"max"` priority (outermost, closest to the caller)
+when no `at` is passed. You can also register at `"min"` priority (innermost,
 closest to the core handler) by passing an options argument:
 
 ```ts
@@ -133,6 +142,51 @@ The execution order with max middlewares `[M1, M2]` and min middlewares
 M1 → M2 → m1 → m2 → core
 ```
 
+## Custom groups
+
+The two-lane default is the right shape for most APIs, but an API can declare
+its own ordered list of middleware groups when more than two structural lanes
+are needed. Each group has a `name` and a `mode`:
+
+- **`"append"`** — earlier registrations run outer. Matches the default
+  `"max"` behavior. Across scopes: parent-outer / child-inner.
+- **`"prepend"`** — later registrations run outer. Matches the default
+  `"min"` behavior. Across scopes: child-outer / parent-inner.
+
+For example, a replay system may need a third lane that sits structurally
+between general wrappers and core-providing middleware:
+
+```ts
+const effects = createApi("effects", handler, {
+  groups: [
+    { name: "max", mode: "append" },
+    { name: "replay", mode: "append" },
+    { name: "min", mode: "prepend" },
+  ] as const,
+});
+
+yield* effects.around(loggingAndOtherWrappers, { at: "max" });
+yield* effects.around(replayRestore, { at: "replay" });
+yield* effects.around(defaultImplementations, { at: "min" });
+yield* effects.around(dispatchOverrides, { at: "min" });
+```
+
+Execution order follows the declared group order, group by group, then the
+core handler:
+
+```text
+max → replay → min → core
+```
+
+Passing `groups: [...] as const` lets TypeScript infer the literal union of
+group names, so `around(..., { at })` is type-checked against the declared
+set. `createApi()` throws at call time if `groups` is empty or has duplicate
+names; `around()` throws at runtime if `at` names a group that was not
+declared.
+
+Default `at` is the first declared group. For the built-in configuration that
+is `"max"`, so existing callers keep their behavior.
+
 ## Instrumentation
 
 Middleware can be useful for automatic instrumentation:
@@ -199,10 +253,15 @@ function* example() {
 
 ## API
 
-### `createApi(name, handler)`
+### `createApi(name, handler, options?)`
 
 Create a context API from a name and an object of handler functions or
 operations. Returns an object with `operations` and `around`.
+
+The optional `options.groups` argument declares the middleware lanes this API
+exposes. Each group has a `name` and a `mode` of `"append"` or `"prepend"`.
+When omitted, it defaults to
+`[{ name: "max", mode: "append" }, { name: "min", mode: "prepend" }]`.
 
 ```ts
 import { createApi } from "@effectionx/context-api";
@@ -223,11 +282,17 @@ function* example(): Operation<void> {
 
 ### `around(middlewares, options?)`
 
-Register middleware around one or more operations. The second argument controls
-priority:
+Register middleware around one or more operations. The second argument chooses
+which declared group to register into.
+
+For the default configuration:
 
 - **`{ at: "max" }`** (default) — outermost, closest to the caller
 - **`{ at: "min" }`** — innermost, closest to the core handler
+
+For APIs that declare custom groups, `at` accepts any declared group name and
+defaults to the first declared group. Passing an unknown name throws at
+runtime.
 
 ```ts
 function* example() {

--- a/context-api/README.md
+++ b/context-api/README.md
@@ -1,14 +1,17 @@
 # Context APIs
 
-Algebraic effects pattern for context-dependent operations with middleware
+Algebraic effects pattern for context-dependent operations with ordered middleware groups
 
 ---
 
 Often called "Algebraic Effects" or "Contextual Effects", Context APIs let you
 access an operation via the context in a way that it can be easily (and
 contextually) wrapped with middleware. Middleware is powered by
-[`@effectionx/middleware`](../middleware/README.md) and supports min/max priority
-ordering.
+[`@effectionx/middleware`](../middleware/README.md) and is organized into
+ordered groups — each API declares the lanes it needs, and middleware within a
+group follows an `append` or `prepend` rule. The default configuration provides
+`max`/`min` lanes, matching the common outer-wrapper / inner-implementation
+split.
 
 ## Quick Start
 

--- a/context-api/mod.ts
+++ b/context-api/mod.ts
@@ -51,6 +51,21 @@ export type MiddlewareGroup<Name extends string> = {
  *
  * `groups` defaults to the backward-compatible two-lane configuration:
  * `[{ name: "max", mode: "append" }, { name: "min", mode: "prepend" }]`.
+ *
+ * Pass `groups: [...] as const` so TypeScript infers the literal union of
+ * group names into the `Group` type parameter. Without `as const`, names
+ * widen to `string` and `around({ at })` loses its typed group check.
+ *
+ * @example
+ * ```ts
+ * const api = createApi("effects", handler, {
+ *   groups: [
+ *     { name: "max", mode: "append" },
+ *     { name: "replay", mode: "append" },
+ *     { name: "min", mode: "prepend" },
+ *   ] as const,
+ * });
+ * ```
  */
 export type CreateApiOptions<Group extends string> = {
   groups?: readonly MiddlewareGroup<Group>[];

--- a/context-api/mod.ts
+++ b/context-api/mod.ts
@@ -60,7 +60,7 @@ export interface Api<A, Group extends string = "max" | "min"> {
   operations: Operations<A>;
   around: (
     around: Partial<Around<A>>,
-    options?: { at?: Group },
+    options?: { at: Group },
   ) => Operation<void>;
 }
 
@@ -202,14 +202,14 @@ export function createApi<A extends {}, Group extends string = "max" | "min">(
 
   function* around(
     middlewares: Partial<Around<A>>,
-    options: { at?: Group } = {},
+    options?: { at: Group },
   ): Operation<void> {
     let hasAny = fields.some((field) => Boolean((middlewares as any)[field]));
     if (!hasAny) {
       return;
     }
 
-    let at = options.at ?? groups[0].name;
+    let at = options?.at ?? groups[0].name;
     let group = groupByName.get(at);
     if (!group) {
       let known = Array.from(groupByName.keys()).join(", ");

--- a/context-api/mod.ts
+++ b/context-api/mod.ts
@@ -26,11 +26,41 @@ export type Around<A> = {
   [K in keyof A]: PropertyMiddleware<A, K>;
 };
 
-export interface Api<A> {
+/**
+ * How repeated registrations inside a group are ordered.
+ *
+ * - `"append"` — earlier registrations run outer (like the default `"max"` lane).
+ *   Across scopes, this means parent-outer / child-inner.
+ * - `"prepend"` — later registrations run outer (like the default `"min"` lane).
+ *   Across scopes, this means child-outer / parent-inner.
+ */
+export type GroupMode = "append" | "prepend";
+
+/**
+ * A user-declared middleware group for a {@link createApi} instance.
+ *
+ * `mode` defaults to `"append"` when omitted.
+ */
+export type MiddlewareGroup<Name extends string> = {
+  name: Name;
+  mode?: GroupMode;
+};
+
+/**
+ * Options accepted by {@link createApi}.
+ *
+ * `groups` defaults to the backward-compatible two-lane configuration:
+ * `[{ name: "max", mode: "append" }, { name: "min", mode: "prepend" }]`.
+ */
+export type CreateApiOptions<Group extends string> = {
+  groups?: readonly MiddlewareGroup<Group>[];
+};
+
+export interface Api<A, Group extends string = "max" | "min"> {
   operations: Operations<A>;
   around: (
     around: Partial<Around<A>>,
-    options?: { at: "min" | "max" },
+    options?: { at?: Group },
   ) => Operation<void>;
 }
 
@@ -55,22 +85,83 @@ export type Operations<A> = {
       : Operation<A[K]>;
 };
 
-type ScopeMiddleware<A> = {
-  max: Partial<Around<A>>[];
-  min: Partial<Around<A>>[];
+type GroupDefinition<Group extends string> = {
+  name: Group;
+  mode: GroupMode;
 };
 
-type MiddlewareStack = {
-  max: Middleware<any[], any>[];
-  min: Middleware<any[], any>[];
-};
+type ScopeMiddleware<A, Group extends string> = Record<
+  Group,
+  Partial<Around<A>>[]
+>;
 
-export function createApi<A extends {}>(name: string, handler: A): Api<A> {
+const DEFAULT_GROUPS: readonly MiddlewareGroup<"max" | "min">[] = [
+  { name: "max", mode: "append" },
+  { name: "min", mode: "prepend" },
+];
+
+export function createApi<A extends {}, Group extends string = "max" | "min">(
+  name: string,
+  handler: A,
+  options?: CreateApiOptions<Group>,
+): Api<A, Group> {
   let fields = Object.keys(handler) as (keyof A)[];
-  let context = createContext<ScopeMiddleware<A>>(`$api:${name}`, {
-    max: [],
-    min: [],
-  });
+
+  let rawGroups = (options?.groups ??
+    DEFAULT_GROUPS) as readonly MiddlewareGroup<Group>[];
+
+  if (rawGroups.length === 0) {
+    throw new Error(`context-api "${name}": \`groups\` must not be empty`);
+  }
+
+  let seen = new Set<string>();
+  let duplicates: string[] = [];
+  let groups: readonly GroupDefinition<Group>[] = Object.freeze(
+    rawGroups.map((g) => {
+      if (seen.has(g.name)) {
+        duplicates.push(g.name);
+      }
+      seen.add(g.name);
+      return Object.freeze({
+        name: g.name,
+        mode: g.mode ?? "append",
+      }) as GroupDefinition<Group>;
+    }),
+  );
+
+  if (duplicates.length > 0) {
+    let unique = Array.from(new Set(duplicates));
+    throw new Error(
+      `context-api "${name}": duplicate group name${unique.length === 1 ? "" : "s"}: ${unique.join(", ")}`,
+    );
+  }
+
+  let groupByName = new Map<string, GroupDefinition<Group>>(
+    groups.map((g) => [g.name, g]),
+  );
+
+  function emptyState(): ScopeMiddleware<A, Group> {
+    let state = {} as ScopeMiddleware<A, Group>;
+    for (let g of groups) {
+      state[g.name] = [];
+    }
+    return state;
+  }
+
+  function cloneState(
+    current: ScopeMiddleware<A, Group>,
+  ): ScopeMiddleware<A, Group> {
+    let next = {} as ScopeMiddleware<A, Group>;
+    for (let g of groups) {
+      next[g.name] = [...(current[g.name] ?? [])];
+    }
+    return next;
+  }
+
+  let context = createContext<ScopeMiddleware<A, Group>>(
+    `$api:${name}`,
+    emptyState(),
+  );
 
   let operations = fields.reduce(
     (api, field) => {
@@ -81,8 +172,13 @@ export function createApi<A extends {}>(name: string, handler: A): Api<A> {
           [field]: (...args: any[]) => ({
             *[Symbol.iterator]() {
               let scope = yield* useScope();
-              let { max, min } = collectMiddleware(scope, context, field);
-              let stack = combine([...max, ...min]);
+              let middlewares = collectMiddleware(
+                scope,
+                context,
+                field,
+                groups,
+              );
+              let stack = combine(middlewares);
               let result = stack(args, fn);
               return isOperation(result) ? yield* result : result;
             },
@@ -93,8 +189,8 @@ export function createApi<A extends {}>(name: string, handler: A): Api<A> {
         [field]: {
           *[Symbol.iterator]() {
             let scope = yield* useScope();
-            let { max, min } = collectMiddleware(scope, context, field);
-            let stack = combine([...max, ...min]);
+            let middlewares = collectMiddleware(scope, context, field, groups);
+            let stack = combine(middlewares);
             let result = stack([], () => handle);
             return isOperation(result) ? yield* result : result;
           },
@@ -106,27 +202,31 @@ export function createApi<A extends {}>(name: string, handler: A): Api<A> {
 
   function* around(
     middlewares: Partial<Around<A>>,
-    options: { at: "min" | "max" } = { at: "max" },
+    options: { at?: Group } = {},
   ): Operation<void> {
     let hasAny = fields.some((field) => Boolean((middlewares as any)[field]));
     if (!hasAny) {
       return;
     }
 
+    let at = options.at ?? groups[0].name;
+    let group = groupByName.get(at);
+    if (!group) {
+      let known = Array.from(groupByName.keys()).join(", ");
+      throw new Error(
+        `context-api "${name}": unknown group "${at}". Known groups: ${known}`,
+      );
+    }
+
     let scope = yield* useScope();
-    let current = scope.hasOwn(context)
-      ? scope.expect(context)
-      : { max: [], min: [] };
+    let current = scope.hasOwn(context) ? scope.expect(context) : emptyState();
 
-    let next: ScopeMiddleware<A> = {
-      max: [...current.max],
-      min: [...current.min],
-    };
+    let next = cloneState(current);
 
-    if (options.at === "min") {
-      next.min = [middlewares, ...next.min];
+    if (group.mode === "prepend") {
+      next[group.name] = [middlewares, ...next[group.name]];
     } else {
-      next.max.push(middlewares);
+      next[group.name] = [...next[group.name], middlewares];
     }
 
     scope.set(context, next);
@@ -135,42 +235,59 @@ export function createApi<A extends {}>(name: string, handler: A): Api<A> {
   return { operations, around };
 }
 
-function collectMiddleware<A extends {}>(
+function collectMiddleware<A extends {}, Group extends string>(
   scope: Scope,
   context: { name?: string; key?: string },
   field: keyof A,
-): MiddlewareStack {
+  groups: readonly GroupDefinition<Group>[],
+): Middleware<any[], any>[] {
   let key = contextName(context);
   let window = contextWindow(scope);
 
-  return reducePrototypeChain(
+  let lanes: Record<string, Middleware<any[], any>[]> = {};
+  for (let g of groups) {
+    lanes[g.name] = [];
+  }
+
+  reducePrototypeChain(
     window,
-    (sum, current) => {
+    (_, current) => {
       if (!Object.prototype.hasOwnProperty.call(current, key)) {
-        return sum;
+        return null;
       }
 
-      let state = current[key] as ScopeMiddleware<A>;
+      let state = current[key] as ScopeMiddleware<A, Group>;
 
-      let max = state.max.flatMap((around) => {
-        let middleware = (around as any)[field] as
-          | Middleware<any[], any>
-          | undefined;
-        return middleware ? [middleware] : [];
-      });
-      let min = state.min.flatMap((around) => {
-        let middleware = (around as any)[field] as
-          | Middleware<any[], any>
-          | undefined;
-        return middleware ? [middleware] : [];
-      });
+      for (let g of groups) {
+        let fromScope = (state[g.name] ?? []).flatMap((around) => {
+          let middleware = (around as any)[field] as
+            | Middleware<any[], any>
+            | undefined;
+          return middleware ? [middleware] : [];
+        });
+        if (g.mode === "append") {
+          // parent outer / child inner — walking child→parent,
+          // parent scopes are encountered last so unshift accumulates
+          // in parent-outer-first order.
+          lanes[g.name].unshift(...fromScope);
+        } else {
+          // child outer / parent inner — walking child→parent, child
+          // scopes are encountered first so push accumulates in
+          // child-outer-first order.
+          lanes[g.name].push(...fromScope);
+        }
+      }
 
-      sum.max.unshift(...max);
-      sum.min.push(...min);
-      return sum;
+      return null;
     },
-    { max: [], min: [] } as MiddlewareStack,
+    null,
   );
+
+  let out: Middleware<any[], any>[] = [];
+  for (let g of groups) {
+    out.push(...lanes[g.name]);
+  }
+  return out;
 }
 
 function reducePrototypeChain<T>(

--- a/context-api/package.json
+++ b/context-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/context-api",
   "description": "Algebraic effects pattern for context-dependent operations with middleware",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "keywords": ["concurrency", "interop"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/context-api/scope-middleware.test.ts
+++ b/context-api/scope-middleware.test.ts
@@ -1569,7 +1569,7 @@ describe("scope middleware", () => {
               ] as const,
             },
           ),
-        ).toThrow(/max/);
+        ).toThrow(/duplicate group names?:[^:]*\bmax\b/);
       });
 
       it("createApi throws on an empty groups array", function* () {

--- a/context-api/scope-middleware.test.ts
+++ b/context-api/scope-middleware.test.ts
@@ -895,4 +895,722 @@ describe("scope middleware", () => {
       expect(yield* api.operations.syncFn()).toEqual(20);
     });
   });
+
+  describe("custom groups", () => {
+    const THREE_LANE = [
+      { name: "max", mode: "append" },
+      { name: "replay", mode: "append" },
+      { name: "min", mode: "prepend" },
+    ] as const;
+
+    it("executes middleware in declared group order", function* () {
+      const api = createApi(
+        "groups.declared-order",
+        {
+          *value(): Operation<string> {
+            return "core";
+          },
+        },
+        { groups: THREE_LANE },
+      );
+
+      const log: string[] = [];
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("max:enter");
+            const result = yield* next(...args);
+            log.push("max:exit");
+            return result;
+          },
+        },
+        { at: "max" },
+      );
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("replay:enter");
+            const result = yield* next(...args);
+            log.push("replay:exit");
+            return result;
+          },
+        },
+        { at: "replay" },
+      );
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min:enter");
+            const result = yield* next(...args);
+            log.push("min:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      yield* api.operations.value();
+      expect(log).toEqual([
+        "max:enter",
+        "replay:enter",
+        "min:enter",
+        "min:exit",
+        "replay:exit",
+        "max:exit",
+      ]);
+    });
+
+    it("append preserves install order within a lane", function* () {
+      const api = createApi(
+        "groups.append-order",
+        {
+          *value(): Operation<string> {
+            return "core";
+          },
+        },
+        { groups: THREE_LANE },
+      );
+
+      const log: string[] = [];
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("max-a:enter");
+            const result = yield* next(...args);
+            log.push("max-a:exit");
+            return result;
+          },
+        },
+        { at: "max" },
+      );
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("max-b:enter");
+            const result = yield* next(...args);
+            log.push("max-b:exit");
+            return result;
+          },
+        },
+        { at: "max" },
+      );
+
+      yield* api.operations.value();
+      expect(log).toEqual([
+        "max-a:enter",
+        "max-b:enter",
+        "max-b:exit",
+        "max-a:exit",
+      ]);
+    });
+
+    it("prepend reverses install order within a lane", function* () {
+      const api = createApi(
+        "groups.prepend-order",
+        {
+          *value(): Operation<string> {
+            return "core";
+          },
+        },
+        { groups: THREE_LANE },
+      );
+
+      const log: string[] = [];
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min-a:enter");
+            const result = yield* next(...args);
+            log.push("min-a:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min-b:enter");
+            const result = yield* next(...args);
+            log.push("min-b:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      yield* api.operations.value();
+      expect(log).toEqual([
+        "min-b:enter",
+        "min-a:enter",
+        "min-a:exit",
+        "min-b:exit",
+      ]);
+    });
+
+    it("middle lane stays between outer and inner regardless of install order", function* () {
+      const api = createApi(
+        "groups.middle-stable",
+        {
+          *value(): Operation<string> {
+            return "core";
+          },
+        },
+        { groups: THREE_LANE },
+      );
+
+      const log: string[] = [];
+
+      // Install in mixed order: min, max, replay, min
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min-1:enter");
+            const result = yield* next(...args);
+            log.push("min-1:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("max-1:enter");
+            const result = yield* next(...args);
+            log.push("max-1:exit");
+            return result;
+          },
+        },
+        { at: "max" },
+      );
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("replay-1:enter");
+            const result = yield* next(...args);
+            log.push("replay-1:exit");
+            return result;
+          },
+        },
+        { at: "replay" },
+      );
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min-2:enter");
+            const result = yield* next(...args);
+            log.push("min-2:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      yield* api.operations.value();
+      // max → replay → min (with min prepend so min-2 before min-1)
+      expect(log).toEqual([
+        "max-1:enter",
+        "replay-1:enter",
+        "min-2:enter",
+        "min-1:enter",
+        "min-1:exit",
+        "min-2:exit",
+        "replay-1:exit",
+        "max-1:exit",
+      ]);
+    });
+
+    it("child extends parent per-group across all lanes", function* () {
+      const api = createApi(
+        "groups.child-extends-parent",
+        {
+          *value(): Operation<string> {
+            return "core";
+          },
+        },
+        { groups: THREE_LANE },
+      );
+
+      const log: string[] = [];
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("max-a:enter");
+            const result = yield* next(...args);
+            log.push("max-a:exit");
+            return result;
+          },
+        },
+        { at: "max" },
+      );
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("replay-a:enter");
+            const result = yield* next(...args);
+            log.push("replay-a:exit");
+            return result;
+          },
+        },
+        { at: "replay" },
+      );
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min-a:enter");
+            const result = yield* next(...args);
+            log.push("min-a:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      yield* scoped(function* () {
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("max-b:enter");
+              const result = yield* next(...args);
+              log.push("max-b:exit");
+              return result;
+            },
+          },
+          { at: "max" },
+        );
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("replay-b:enter");
+              const result = yield* next(...args);
+              log.push("replay-b:exit");
+              return result;
+            },
+          },
+          { at: "replay" },
+        );
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("min-b:enter");
+              const result = yield* next(...args);
+              log.push("min-b:exit");
+              return result;
+            },
+          },
+          { at: "min" },
+        );
+
+        yield* api.operations.value();
+      });
+
+      // append lanes: parent outer / child inner (a outer, b inner)
+      // prepend lane: child outer / parent inner (b outer, a inner)
+      expect(log).toEqual([
+        "max-a:enter",
+        "max-b:enter",
+        "replay-a:enter",
+        "replay-b:enter",
+        "min-b:enter",
+        "min-a:enter",
+        "min-a:exit",
+        "min-b:exit",
+        "replay-b:exit",
+        "replay-a:exit",
+        "max-b:exit",
+        "max-a:exit",
+      ]);
+    });
+
+    it("child custom-group middleware does not leak back to parent", function* () {
+      const api = createApi(
+        "groups.no-leak",
+        {
+          *value(): Operation<string> {
+            return "core";
+          },
+        },
+        { groups: THREE_LANE },
+      );
+
+      const log: string[] = [];
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("max-a:enter");
+            const result = yield* next(...args);
+            log.push("max-a:exit");
+            return result;
+          },
+        },
+        { at: "max" },
+      );
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("replay-a:enter");
+            const result = yield* next(...args);
+            log.push("replay-a:exit");
+            return result;
+          },
+        },
+        { at: "replay" },
+      );
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min-a:enter");
+            const result = yield* next(...args);
+            log.push("min-a:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      yield* scoped(function* () {
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("max-b:enter");
+              const result = yield* next(...args);
+              log.push("max-b:exit");
+              return result;
+            },
+          },
+          { at: "max" },
+        );
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("replay-b:enter");
+              const result = yield* next(...args);
+              log.push("replay-b:exit");
+              return result;
+            },
+          },
+          { at: "replay" },
+        );
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("min-b:enter");
+              const result = yield* next(...args);
+              log.push("min-b:exit");
+              return result;
+            },
+          },
+          { at: "min" },
+        );
+
+        yield* api.operations.value();
+      });
+
+      log.length = 0;
+      yield* api.operations.value();
+      expect(log).toEqual([
+        "max-a:enter",
+        "replay-a:enter",
+        "min-a:enter",
+        "min-a:exit",
+        "replay-a:exit",
+        "max-a:exit",
+      ]);
+    });
+
+    it("spawned child sees later parent replay middleware", function* () {
+      const api = createApi(
+        "groups.spawn-replay",
+        {
+          *value(): Operation<string> {
+            return "core";
+          },
+        },
+        { groups: THREE_LANE },
+      );
+
+      const log: string[] = [];
+      const gate = withResolvers<void>();
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("replay-a:enter");
+            const result = yield* next(...args);
+            log.push("replay-a:exit");
+            return result;
+          },
+        },
+        { at: "replay" },
+      );
+
+      const task = yield* spawn(function* () {
+        yield* gate.operation;
+        return yield* api.operations.value();
+      });
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("replay-b:enter");
+            const result = yield* next(...args);
+            log.push("replay-b:exit");
+            return result;
+          },
+        },
+        { at: "replay" },
+      );
+
+      gate.resolve();
+
+      const result = yield* task;
+      expect(result).toEqual("core");
+      // Spawned child reads live context: sees both earlier and later replay.
+      // replay is append, so replay-a runs outer.
+      expect(log).toEqual([
+        "replay-a:enter",
+        "replay-b:enter",
+        "replay-b:exit",
+        "replay-a:exit",
+      ]);
+    });
+
+    it("mixed later parent updates across all three lanes remain deterministic", function* () {
+      const api = createApi(
+        "groups.mixed-later-updates",
+        {
+          *value(): Operation<string> {
+            return "core";
+          },
+        },
+        { groups: THREE_LANE },
+      );
+
+      const log: string[] = [];
+      const childReady = withResolvers<void>();
+      const parentUpdated = withResolvers<void>();
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("max-a:enter");
+            const result = yield* next(...args);
+            log.push("max-a:exit");
+            return result;
+          },
+        },
+        { at: "max" },
+      );
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("replay-a:enter");
+            const result = yield* next(...args);
+            log.push("replay-a:exit");
+            return result;
+          },
+        },
+        { at: "replay" },
+      );
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min-a:enter");
+            const result = yield* next(...args);
+            log.push("min-a:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      const task = yield* spawn(function* () {
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("max-b:enter");
+              const result = yield* next(...args);
+              log.push("max-b:exit");
+              return result;
+            },
+          },
+          { at: "max" },
+        );
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("replay-b:enter");
+              const result = yield* next(...args);
+              log.push("replay-b:exit");
+              return result;
+            },
+          },
+          { at: "replay" },
+        );
+        yield* api.around(
+          {
+            *value(args, next) {
+              log.push("min-b:enter");
+              const result = yield* next(...args);
+              log.push("min-b:exit");
+              return result;
+            },
+          },
+          { at: "min" },
+        );
+
+        childReady.resolve();
+        yield* parentUpdated.operation;
+        return yield* api.operations.value();
+      });
+
+      yield* childReady.operation;
+
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("max-c:enter");
+            const result = yield* next(...args);
+            log.push("max-c:exit");
+            return result;
+          },
+        },
+        { at: "max" },
+      );
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("replay-c:enter");
+            const result = yield* next(...args);
+            log.push("replay-c:exit");
+            return result;
+          },
+        },
+        { at: "replay" },
+      );
+      yield* api.around(
+        {
+          *value(args, next) {
+            log.push("min-c:enter");
+            const result = yield* next(...args);
+            log.push("min-c:exit");
+            return result;
+          },
+        },
+        { at: "min" },
+      );
+
+      parentUpdated.resolve();
+
+      const childResult = yield* task;
+      expect(childResult).toEqual("core");
+      // append lanes (max, replay): parent outer / child inner;
+      // parent install order preserved (a then c), child appended inner.
+      // prepend lane (min): child outer / parent inner, with later installs outermost.
+      expect(log).toEqual([
+        "max-a:enter",
+        "max-c:enter",
+        "max-b:enter",
+        "replay-a:enter",
+        "replay-c:enter",
+        "replay-b:enter",
+        "min-b:enter",
+        "min-c:enter",
+        "min-a:enter",
+        "min-a:exit",
+        "min-c:exit",
+        "min-b:exit",
+        "replay-b:exit",
+        "replay-c:exit",
+        "replay-a:exit",
+        "max-b:exit",
+        "max-c:exit",
+        "max-a:exit",
+      ]);
+    });
+
+    describe("validation", () => {
+      it("createApi throws on duplicate group names", function* () {
+        expect(() =>
+          createApi(
+            "groups.dup",
+            { *v(): Operation<void> {} },
+            {
+              groups: [
+                { name: "max", mode: "append" },
+                { name: "replay", mode: "append" },
+                { name: "max", mode: "prepend" },
+              ] as const,
+            },
+          ),
+        ).toThrow(/duplicate group name/);
+
+        expect(() =>
+          createApi(
+            "groups.dup",
+            { *v(): Operation<void> {} },
+            {
+              groups: [
+                { name: "max", mode: "append" },
+                { name: "max", mode: "prepend" },
+              ] as const,
+            },
+          ),
+        ).toThrow(/max/);
+      });
+
+      it("createApi throws on an empty groups array", function* () {
+        expect(() =>
+          createApi(
+            "groups.empty",
+            { *v(): Operation<void> {} },
+            { groups: [] as const },
+          ),
+        ).toThrow(/must not be empty/);
+      });
+
+      it("around throws on unknown `at` with known names in the error message", function* () {
+        const api = createApi(
+          "groups.unknown-at",
+          { *v(): Operation<void> {} },
+          { groups: THREE_LANE },
+        );
+
+        let error: unknown;
+        try {
+          yield* api.around(
+            {
+              *v(args, next) {
+                yield* next(...args);
+              },
+            },
+            // deliberately cast to bypass the compile-time guard
+            { at: "nope" as unknown as "max" | "replay" | "min" },
+          );
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).toBeInstanceOf(Error);
+        const message = (error as Error).message;
+        expect(message).toMatch(/unknown group "nope"/);
+        expect(message).toMatch(/max/);
+        expect(message).toMatch(/replay/);
+        expect(message).toMatch(/min/);
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Motivation

Consumers of `@effectionx/context-api` (notably Tisyn) need a third structural middleware lane that sits between general wrappers and core-providing middleware — specifically, a `replay` lane positioned as `max wrappers → replay restore → dispatch/default min → core`.

Today `context-api` hard-codes exactly two lanes (`max` and `min`), so replay restore has to compete with other `min` middleware by install order. That encodes a fragile invariant in call ordering instead of in the API surface. The fix is to let each `createApi()` declare the lanes it needs, keeping `max`/`min` as the backward-compatible default.

# Approach

- New optional `options.groups` on `createApi()`: an ordered list of `{ name, mode }` where `mode` is `"append"` (earlier registrations outer; parent-outer/child-inner across scopes) or `"prepend"` (later registrations outer; child-outer/parent-inner).
- `around({ at })` now targets any declared group name; `at` defaults to the first declared group.
- Default groups remain `[{ name: "max", mode: "append" }, { name: "min", mode: "prepend" }]`, so existing call sites — including the "defaults to max" semantics — are unchanged.
- Validation at `createApi()` call time: throws on empty `groups` and on duplicate names; `around()` throws at runtime on an unknown `at`, with the known group names in the message.
- New public types: `GroupMode`, `MiddlewareGroup<Name>`, `CreateApiOptions<Group>`. `Api<A, Group>` gains a second generic with a default of `"max" | "min"` so existing `Api<A>` usages keep compiling. Callers pass `groups: [...] as const` to infer the literal union.
- Tests: added a `describe("custom groups", ...)` block in `scope-middleware.test.ts` covering declared order, install-order semantics per mode, middle-lane stability, parent/child composition across all lanes, isolation after scope exit, live updates for spawned tasks on the middle lane, mixed later-parent updates, and all three validation paths. Existing tests unchanged.
- README: updated the "Min/Max Priority" section to frame it as the default configuration and added a "Custom groups" subsection with the three-lane example and execution-order diagram. Updated the `createApi` and `around` API reference entries.

Verification (all green): `pnpm check`, `pnpm lint`, `pnpm fmt:check`, and `pnpm test` (389 passing, 6 skipped — 11 new tests). No runtime behavior change for existing `max`/`min` callers.