### PR TITLE
📦 Tighten publish tarballs: restrict files to dist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Each package requires:
 - `type`: `"module"`
 - `exports`: Must include `types`, `development`, `import`, and `default` conditions
 - `peerDependencies`: Usually `effection: "^3 || ^4"`
-- `files`: Include `dist`, `mod.ts`, and source files
+- `files`: Include only published artifacts (`dist`). Exceptions: `bdd` also ships `mod.deno.ts` (the `./deno` subpath serves source directly); `inline` also ships `swc/target/wasm32-wasip1/release/swc_plugin_inline.wasm`. Workspace dev resolves source via the `development` export condition — source `.ts` files do not need to be in `files`
 
 ### Test Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ Each package requires:
 - `type`: `"module"`
 - `exports`: Must include `types`, `development`, `import`, and `default` conditions
 - `peerDependencies`: Usually `effection: "^3 || ^4"`
-- `files`: Include `dist`, `mod.ts`, and source files
+- `files`: Include only published artifacts (`dist`). Exceptions: `bdd` also ships `mod.deno.ts` (the `./deno` subpath serves source directly); `inline` also ships `swc/target/wasm32-wasip1/release/swc_plugin_inline.wasm`. Workspace dev resolves source via the `development` export condition — source `.ts` files do not need to be in `files`
 
 ### Test Files
 

--- a/bdd/package.json
+++ b/bdd/package.json
@@ -26,6 +26,7 @@
       "default": "./mod.deno.ts"
     }
   },
+  "files": ["dist", "mod.deno.ts"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/chain/package.json
+++ b/chain/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/context-api/package.json
+++ b/context-api/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/thefrontside/effectionx/issues"
   },
   "sideEffects": false,
-  "files": ["dist", "mod.ts"],
+  "files": ["dist"],
   "devDependencies": {
     "@effectionx/vitest": "workspace:*",
     "effection": "^4"

--- a/converge/package.json
+++ b/converge/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/effect-ts/package.json
+++ b/effect-ts/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effect": "^3",
     "effection": "^3 || ^4"

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -14,7 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
-  "files": ["dist", "mod.ts", "api.ts", "create-fetch-response.ts", "fetch.ts"],
+  "files": ["dist"],
   "dependencies": {
     "@effectionx/context-api": "workspace:*"
   },

--- a/fs/package.json
+++ b/fs/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "dependencies": {
     "@effectionx/context-api": "workspace:*"
   },

--- a/fx/package.json
+++ b/fx/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/inline/package.json
+++ b/inline/package.json
@@ -45,12 +45,7 @@
     "build:bundle": "cargo build --manifest-path swc/Cargo.toml --target wasm32-wasip1 --release",
     "prepack": "pnpm run build:bundle"
   },
-  "files": [
-    "dist",
-    "mod.ts",
-    "esbuild.ts",
-    "swc/target/wasm32-wasip1/release/swc_plugin_inline.wasm"
-  ],
+  "files": ["dist", "swc/target/wasm32-wasip1/release/swc_plugin_inline.wasm"],
   "sideEffects": false,
   "devDependencies": {
     "@effectionx/bdd": "workspace:*",

--- a/inline/package.json
+++ b/inline/package.json
@@ -2,6 +2,7 @@
   "name": "@effectionx/inline",
   "description": "Optimize deeply nested operations by collapsing yield delegation into a single iterator",
   "version": "0.0.1",
+  "keywords": ["concurrency"],
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",

--- a/inline/package.json
+++ b/inline/package.json
@@ -2,6 +2,7 @@
   "name": "@effectionx/inline",
   "description": "Optimize deeply nested operations by collapsing yield delegation into a single iterator",
   "version": "0.0.2",
+  "keywords": ["concurrency"],
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",

--- a/jsonl-store/package.json
+++ b/jsonl-store/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -14,7 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
-  "files": ["dist", "mod.ts", "middleware.ts"],
+  "files": ["dist"],
   "license": "MIT",
   "author": "engineering@frontside.com",
   "repository": {

--- a/node/package.json
+++ b/node/package.json
@@ -26,6 +26,7 @@
       "default": "./dist/events.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/process/package.json
+++ b/process/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/raf/package.json
+++ b/raf/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/scope-eval/package.json
+++ b/scope-eval/package.json
@@ -14,7 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
-  "files": ["dist", "mod.ts", "box.ts", "eval-scope.ts"],
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/signals/package.json
+++ b/signals/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/state-api/package.json
+++ b/state-api/package.json
@@ -21,7 +21,7 @@
       "default": "./dist/mod.js"
     }
   },
-  "files": ["dist", "mod.ts", "state.ts"],
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/stream-helpers/package.json
+++ b/stream-helpers/package.json
@@ -20,6 +20,7 @@
       "default": "./dist/test-helpers.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/stream-yaml/package.json
+++ b/stream-yaml/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/task-buffer/package.json
+++ b/task-buffer/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/test-adapter/package.json
+++ b/test-adapter/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/timebox/package.json
+++ b/timebox/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/tinyexec/package.json
+++ b/tinyexec/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/vitest/package.json
+++ b/vitest/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4",
     "vitest": "^3 || ^4"

--- a/watch/package.json
+++ b/watch/package.json
@@ -20,6 +20,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/websocket/package.json
+++ b/websocket/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/worker/package.json
+++ b/worker/package.json
@@ -14,6 +14,7 @@
       "default": "./dist/mod.js"
     }
   },
+  "files": ["dist"],
   "peerDependencies": {
     "effection": "^3 || ^4"
   },


### PR DESCRIPTION
## Summary

- Adds (or narrows) a top-level `files` array on all 27 workspace-published `@effectionx/*` packages so source `.ts` no longer ships in the tarball.
- Top-level `exports` is untouched — `.internal/strip-dev-exports.ts` already removes the `development` condition at publish time, and workspace dev keeps resolving source via pnpm symlinks + the `development` condition.
- `AGENTS.md` updated so the documented `files` requirement matches the new shape.

## Why not `publishConfig`

`publishConfig.exports` / `publishConfig.files` were tried first and rejected — verified on npm 11.6.2 that they do not override the top-level `exports` or `files` during `npm pack`. The top-level `files` field is the only mechanism that actually shapes the tarball.

## Per-package shape

- `bdd` → `["dist", "mod.deno.ts"]` — the `./deno` subpath intentionally serves source `.ts` (Deno consumes `.ts` directly).
- `inline` → `["dist", "swc/target/wasm32-wasip1/release/swc_plugin_inline.wasm"]` — keeps the SWC WASM artifact.
- All other 25 packages → `["dist"]`.

## Scope

27 workspace-published `@effectionx/*` packages (source of truth: `pnpm-workspace.yaml`). `deno-deploy` is deliberately excluded — it's commented out of the workspace as deprecated, so `.internal/strip-dev-exports.ts` doesn't walk it and `pnpm publish` doesn't publish it.

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm check` — clean
- [x] `pnpm test` — 104 real package test files pass (767 tests, 12 pre-existing skips). The 50 "failures" are all inside `.claude/worktrees/agent-*` — stale git worktrees that Vitest picks up as duplicate test files; unrelated to this PR.
- [x] Packed-tarball simulation: `rsync` edited tree → `node --experimental-strip-types .internal/strip-dev-exports.ts` → `npm pack` on `fx`, `context-api`, `bdd`, `node`. Verified per tarball:
  - No `"development"` key anywhere in published `exports`.
  - `files` matches the plan.
  - No top-level `.ts` in any tarball except `bdd/mod.deno.ts` (intentional).
  - `dist/` present everywhere.
- [x] `inline` post-strip manifest inspected directly: `exports` clean, `files` keeps only `dist` + WASM. (WASM build itself requires a Rust toolchain upgrade unrelated to this PR.)
- [x] Strip script reports "stripped 27 package(s)" — matches chosen scope exactly.

Manifest-only change — per `.policies/version-bump.md`, no changeset / version bump required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified package publishing guidance, including development workflow behavior and exceptions for Deno and WASM runtime assets.

* **Chores**
  * Standardized published package contents to include compiled artifacts and required runtime assets while excluding unnecessary source files.
  * Added the `concurrency` keyword to improve package discoverability.
  * No public APIs or runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->