### PR TITLE
👷 Fix @effectionx/inline wasm plugin build

### DIFF
--- a/inline/.cargo/config.toml
+++ b/inline/.cargo/config.toml
@@ -1,0 +1,15 @@
+# This file lives at the package root (inline/.cargo), not next to the crate
+# (inline/swc), because `build:bundle` runs cargo from inline/ with
+# `--manifest-path swc/Cargo.toml`, and cargo discovers config relative to the
+# working directory. Placed under swc/ these rustflags would be silently ignored.
+#
+# Required for backward compatibility with @swc/core >= 1.15.0.
+# Enables the Unknown variant on AST enums so the plugin can handle
+# node types introduced in newer SWC versions.
+#
+# --allow-undefined keeps the SWC host-ABI symbols (__emit_diagnostics,
+# *_proxy, __set_transform_result, …) as wasm imports resolved by the plugin
+# host at runtime. Newer rust-lld/wasm-ld no longer leaves undefined symbols as
+# imports by default, so without this the release link fails for the plugin.
+[target.'cfg(target_arch = "wasm32")']
+rustflags = ["--cfg=swc_ast_unknown", "-C", "link-arg=--allow-undefined"]

--- a/inline/swc/.cargo/config.toml
+++ b/inline/swc/.cargo/config.toml
@@ -1,5 +1,0 @@
-# Required for backward compatibility with @swc/core >= 1.15.0.
-# Enables the Unknown variant on AST enums so the plugin can handle
-# node types introduced in newer SWC versions.
-[target.'cfg(target_arch = "wasm32")']
-rustflags = ["--cfg=swc_ast_unknown"]


### PR DESCRIPTION
# Motivation

CI is red at the **Build** step on PRs (e.g. #218) — not in tests. The failure
is `@effectionx/inline#build:bundle` (exit 101): compiling `swc-plugin-inline`
to `wasm32-wasip1` fails to link under current Rust:

```
rust-lld: error: undefined symbol: __emit_diagnostics
rust-lld: error: undefined symbol: __set_transform_result
rust-lld: error: undefined symbol: __add_leading_comment_proxy
…
```

Those `__*` / `*_proxy` symbols are the SWC **host ABI** functions an SWC wasm
plugin imports from its runtime host — they are meant to stay as undefined
imports in the `.wasm`. Newer `rust-lld`/`wasm-ld` no longer leaves undefined
symbols as imports by default, so the release link errors.

There were actually **two** problems:

1. The link needs `-C link-arg=--allow-undefined` to keep the host-ABI symbols
   as imports.
2. The crate's cargo config (`inline/swc/.cargo/config.toml`) was never being
   applied. `build:bundle` runs cargo from `inline/`
   (`cargo build --manifest-path swc/Cargo.toml …`), and cargo discovers
   `.cargo/config.toml` relative to the **working directory**, not the manifest.
   So the rustflags there — including the pre-existing `--cfg=swc_ast_unknown` —
   were silently ignored in CI.

# Approach

Move the cargo config to the package root, `inline/.cargo/config.toml`, so it is
discovered from the directory `build:bundle` runs in, and add the
`--allow-undefined` link arg:

```toml
[target.'cfg(target_arch = "wasm32")']
rustflags = ["--cfg=swc_ast_unknown", "-C", "link-arg=--allow-undefined"]
```

This makes both the existing `swc_ast_unknown` cfg and the new link arg take
effect. A comment documents why the file must live at `inline/.cargo` rather than
next to the crate.

## Verification (local)

- `rustup` stable **1.96.0** (newer than CI's toolchain) + `wasm32-wasip1`:
  - `pnpm --filter @effectionx/inline run build:bundle` — links cleanly, emits
    `swc_plugin_inline.wasm`. Reproduced the original failure first, then
    confirmed the fix via the exact CI invocation.
  - `pnpm build` — full `tsc --build` + `turbo run build:bundle` green.
  - `node --env-file=.env --test "inline/*.test.ts"` — **32/32** pass, including
    `swc.test.ts`, which loads and runs the built wasm plugin.

Scoped entirely to `inline/`; no workflow or other-package changes. Unblocks the
Build step on #218.