### PR TITLE
fix: refresh stale internal dependency pins (process, watch)

### DIFF
--- a/process/package.json
+++ b/process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/process",
   "description": "Spawn and manage child processes with structured concurrency",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/watch/package.json
+++ b/watch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/watch",
   "description": "Run commands and restart them gracefully when source files change",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/main.js",


### PR DESCRIPTION
## Problem

A consumer reported getting **two copies of `@effectionx/context-api`** in their dependency tree when using `@effectionx/process` alongside a direct, up-to-date `context-api` dependency.

### Root cause

Source packages declare internal deps as `workspace:*`. When `pnpm publish` runs, it rewrites `workspace:*` to the **exact** dependency version at publish time. Because these packages are pre-1.0 (`0.x`), semver treats every **minor** bump (`0.5` → `0.6`) as breaking — so a published exact pin like `context-api: "0.5.3"` will never dedupe against a newer `0.6.0` a consumer pulls in directly. Result: duplicate copies in the tree.

The latest published packages had these stale pins:

| Package | pinned | latest |
|---|---|---|
| `process@0.8.0` | `context-api: 0.5.3` | **0.6.0** |
| `watch@0.4.4` | `process: 0.7.4` | **0.8.0** |
| `watch@0.4.4` | `fs: 0.2.3` | **0.3.0** |

## Fix

Patch-bump the affected packages so the publish workflow (`.internal/publish-matrix.ts` republishes any version not yet on npm) re-releases them, capturing fresh pins:

- `@effectionx/process` `0.8.0` → `0.8.1` (will pin `context-api@0.6.0`)
- `@effectionx/watch` `0.4.4` → `0.4.5` (will pin `process@0.8.1`, `fs@0.3.0`)

Since both are published from the same commit, `watch` picks up the new `process@0.8.1`, so the whole `watch → process → context-api` chain resolves to a single `context-api@0.6.0`.

## Follow-up (not in this PR)

This will recur whenever an internal dep gets a minor bump and its dependents aren't re-released. Worth considering **changesets** (auto-bumps dependents and rewrites pins) or widening pre-1.0 ranges so cross-minor dedupe works. Happy to open a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions: `@effectionx/process` to 0.8.1 and `@effectionx/watch` to 0.4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->