### PR TITLE
✨ Add WebSocket server to @effectionx/websocket

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,9 @@ importers:
       '@effectionx/node':
         specifier: workspace:*
         version: link:../node
+      '@effectionx/timebox':
+        specifier: workspace:*
+        version: link:../timebox
     devDependencies:
       '@effectionx/vitest':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,10 @@ importers:
         version: 4.1.0
 
   websocket:
+    dependencies:
+      '@effectionx/node':
+        specifier: workspace:*
+        version: link:../node
     devDependencies:
       '@effectionx/vitest':
         specifier: workspace:*

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -58,10 +58,10 @@ let socket = yield* useWebSocket("ws://websocket.example.org", {
 
 ## WebSocket Server
 
-`useWebSocketServer()` is the server counterpart of `useWebSocket()`. It yields a
-stream of incoming connections, where **each connection is the same full-duplex
-`WebSocketResource`** produced by the client — you receive messages by iterating
-it and reply with `yield* connection.send()`.
+`useWebSocketServer()` is the server counterpart of `useWebSocket()`. It hands
+back a subscription of incoming connections, where **each connection is the same
+full-duplex `WebSocketResource`** produced by the client — you receive messages
+by iterating it and reply with `yield* connection.send()`.
 
 The underlying server is supplied through a factory, so this package never
 imports a concrete server implementation and stays platform-agnostic. On Node
@@ -70,27 +70,24 @@ this is typically the [`ws`](https://github.com/websockets/ws) `WebSocketServer`
 ```typescript
 import { each, main, spawn } from "effection";
 import { WebSocketServer } from "ws";
-import {
-  useWebSocketServer,
-  type WebSocketServerLike,
-} from "@effectionx/websocket";
+import { useWebSocketServer } from "@effectionx/websocket";
 
 await main(function* () {
-  let server = yield* useWebSocketServer<string>(
-    () => new WebSocketServer({ port: 3000 }) as unknown as WebSocketServerLike,
+  let connections = yield* useWebSocketServer<string>(
+    () => new WebSocketServer({ port: 3000 }),
     { closeTimeout: 5_000 },
   );
 
-  // A stream is consumed sequentially, so spawn a handler per connection to
+  // Connections are read one at a time, so spawn a handler per connection to
   // serve many clients concurrently.
-  for (let connection of yield* each(server)) {
+  while (true) {
+    let { value: connection } = yield* connections.next();
     yield* spawn(function* () {
       for (let message of yield* each(connection)) {
         yield* connection.send(`echo: ${message.data}`);
         yield* each.next();
       }
     });
-    yield* each.next();
   }
 });
 ```
@@ -114,11 +111,15 @@ await main(function* () {
 });
 ```
 
-Connections are buffered, so none are dropped between the moment the server
-starts listening and the moment you begin iterating. The server — and every live
-connection it produced — is automatically closed when the resource passes out of
-scope. The server's second argument configures the close-handshake timeout for
-every accepted connection.
+Connections are buffered from the moment the resource is created, so none are
+dropped before you start reading. That is why the server is a subscription rather
+than a stream: reading a connection consumes it, and every consumer draws from
+the same buffer instead of getting an independent replay.
+
+The server — and every live connection it produced — is automatically closed when
+the resource passes out of scope, with close code `1001` ("going away"). The
+server's second argument configures the close-handshake timeout for every
+accepted connection.
 
 ## Advanced Usage
 

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -26,7 +26,7 @@ await main(function* () {
   let socket = yield* useWebSocket("ws://websocket.example.org");
 
   // Send messages to the server
-  socket.send("Hello World");
+  yield* socket.send("Hello World");
 
   // Receive messages using a simple iterator
   for (let message of yield* each(socket)) {
@@ -45,6 +45,68 @@ await main(function* () {
 - **Stream-based API**: Messages are delivered through a simple stream interface
 - **Clean Resource Management**: Connections are properly cleaned up when the
   operation completes
+
+## WebSocket Server
+
+`useWebSocketServer()` is the server counterpart of `useWebSocket()`. It yields a
+stream of incoming connections, where **each connection is the same full-duplex
+`WebSocketResource`** produced by the client — you receive messages by iterating
+it and reply with `yield* connection.send()`.
+
+The underlying server is supplied through a factory, so this package never
+imports a concrete server implementation and stays platform-agnostic. On Node
+this is typically the [`ws`](https://github.com/websockets/ws) `WebSocketServer`.
+
+```typescript
+import { each, main, spawn } from "effection";
+import { WebSocketServer } from "ws";
+import {
+  useWebSocketServer,
+  type WebSocketServerLike,
+} from "@effectionx/websocket";
+
+await main(function* () {
+  let server = yield* useWebSocketServer<string>(
+    () => new WebSocketServer({ port: 3000 }) as unknown as WebSocketServerLike,
+  );
+
+  // A stream is consumed sequentially, so spawn a handler per connection to
+  // serve many clients concurrently.
+  for (let connection of yield* each(server)) {
+    yield* spawn(function* () {
+      for (let message of yield* each(connection)) {
+        yield* connection.send(`echo: ${message.data}`);
+        yield* each.next();
+      }
+    });
+    yield* each.next();
+  }
+});
+```
+
+A client — using `useWebSocket()` from the same package — pairs with it directly.
+Because `send` is an `Operation`, invoke it with `yield*` on both sides:
+
+```typescript
+import { each, main } from "effection";
+import { useWebSocket } from "@effectionx/websocket";
+
+await main(function* () {
+  let socket = yield* useWebSocket<string>("ws://localhost:3000");
+
+  yield* socket.send("hello"); // client -> server
+
+  for (let message of yield* each(socket)) {
+    console.log(message.data); // "echo: hello"  (server -> client)
+    yield* each.next();
+  }
+});
+```
+
+Connections are buffered, so none are dropped between the moment the server
+starts listening and the moment you begin iterating. The server — and every live
+connection it produced — is automatically closed when the resource passes out of
+scope.
 
 ## Advanced Usage
 

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -121,6 +121,27 @@ the resource passes out of scope, with close code `1001` ("going away"). The
 server's second argument configures the close-handshake timeout for every
 accepted connection.
 
+### Observing connection failures
+
+The two kinds of failure are reported differently. An error on the server itself
+crashes the resource's scope, reaching your error boundary like any other
+failure. An error on a single connection is isolated so it cannot take the server
+down, and is published on `server.errors` instead — spawn a task to watch that
+stream if you want to see them:
+
+```typescript
+yield* spawn(function* () {
+  for (let error of yield* each(connections.errors)) {
+    // a socket failure throws the DOM `error` event, which is not an `Error`;
+    // effection 4.1+ boxes it and keeps the original on `cause`
+    console.error("connection failed:", (error as Error)?.cause ?? error);
+    yield* each.next();
+  }
+});
+```
+
+`errors` is lossy: failures raised while nobody is subscribed are not buffered.
+
 ## Advanced Usage
 
 ### Custom WebSocket Implementations

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -36,6 +36,16 @@ await main(function* () {
 });
 ```
 
+By default, teardown waits up to one second for the peer's close handshake.
+Configure that deadline when creating the resource if your environment needs a
+different shutdown policy:
+
+```typescript
+let socket = yield* useWebSocket("ws://websocket.example.org", {
+  closeTimeout: 5_000,
+});
+```
+
 ## Features
 
 - **Ready-to-use Connections**: `useWebSocket()` returns only after the
@@ -68,6 +78,7 @@ import {
 await main(function* () {
   let server = yield* useWebSocketServer<string>(
     () => new WebSocketServer({ port: 3000 }) as unknown as WebSocketServerLike,
+    { closeTimeout: 5_000 },
   );
 
   // A stream is consumed sequentially, so spawn a handler per connection to
@@ -106,7 +117,8 @@ await main(function* () {
 Connections are buffered, so none are dropped between the moment the server
 starts listening and the moment you begin iterating. The server — and every live
 connection it produced — is automatically closed when the resource passes out of
-scope.
+scope. The server's second argument configures the close-handshake timeout for
+every accepted connection.
 
 ## Advanced Usage
 

--- a/websocket/mod.ts
+++ b/websocket/mod.ts
@@ -1,1 +1,2 @@
 export * from "./websocket.ts";
+export * from "./server.ts";

--- a/websocket/package.json
+++ b/websocket/package.json
@@ -15,6 +15,9 @@
     }
   },
   "files": ["dist"],
+  "dependencies": {
+    "@effectionx/node": "workspace:*"
+  },
   "peerDependencies": {
     "effection": "^3 || ^4"
   },

--- a/websocket/package.json
+++ b/websocket/package.json
@@ -16,7 +16,8 @@
   },
   "files": ["dist"],
   "dependencies": {
-    "@effectionx/node": "workspace:*"
+    "@effectionx/node": "workspace:*",
+    "@effectionx/timebox": "workspace:*"
   },
   "peerDependencies": {
     "effection": "^3 || ^4"

--- a/websocket/package.json
+++ b/websocket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/websocket",
-  "description": "WebSocket client with stream-based message handling and automatic cleanup",
-  "version": "2.3.4",
+  "description": "WebSocket client and server with stream-based message handling and automatic cleanup",
+  "version": "3.0.0",
   "keywords": ["io", "streams"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/websocket/server.test.ts
+++ b/websocket/server.test.ts
@@ -11,7 +11,7 @@ import {
   withResolvers,
 } from "effection";
 import { expect } from "expect";
-import { WebSocketServer } from "ws";
+import { WebSocketServer, type WebSocket as WsWebSocket } from "ws";
 
 import {
   type WebSocketServerLike,
@@ -128,6 +128,41 @@ describe("WebSocketServer", () => {
 
     let { value } = yield* messages.next();
     expect(value).toMatchObject({ data: "buffered hello" });
+  });
+
+  it("isolates a connection error so the server keeps serving other clients", function* () {
+    let { httpServer, port } = yield* useHttp();
+
+    // capture the raw accepted sockets so we can force an error on one
+    let wss = new WebSocketServer({ server: httpServer });
+    let rawSockets = createQueue<WsWebSocket, never>();
+    wss.on("connection", (ws) => rawSockets.add(ws));
+
+    let server = yield* useWebSocketServer<string>(
+      () => wss as unknown as WebSocketServerLike,
+    );
+    let incoming = yield* server;
+    let serverErrors = yield* server.errors;
+
+    // accept one client, then make its underlying socket error
+    yield* connect(port);
+    yield* incoming.next();
+    let raw = (yield* rawSockets.next()).value;
+    raw.emit("error", new Error("boom"));
+
+    // the failure is surfaced on the errors stream, not thrown at the server.
+    // A socket failure surfaces as the DOM `error` event, whose message is the
+    // underlying error's message.
+    let { value: error } = yield* serverErrors.next();
+    expect((error as ErrorEvent).message).toContain("boom");
+
+    // and the server survives, serving a fresh client
+    let client = yield* connect(port);
+    let connection = (yield* incoming.next()).value;
+    let messages = yield* connection;
+    yield* client.send("still alive");
+    let { value } = yield* messages.next();
+    expect(value).toMatchObject({ data: "still alive" });
   });
 
   it("surfaces each simultaneous client as a distinct connection", function* () {

--- a/websocket/server.test.ts
+++ b/websocket/server.test.ts
@@ -1,0 +1,183 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, it } from "@effectionx/vitest";
+import {
+  type Operation,
+  type Subscription,
+  createQueue,
+  resource,
+  spawn,
+  suspend,
+  withResolvers,
+} from "effection";
+import { expect } from "expect";
+import { WebSocketServer } from "ws";
+
+import {
+  type WebSocketServerLike,
+  type WebSocketServerResource,
+  useWebSocketServer,
+} from "./server.ts";
+import { type WebSocketResource, useWebSocket } from "./websocket.ts";
+
+describe("WebSocketServer", () => {
+  it("yields a connection and receives a message from the client", function* () {
+    let { server, port } = yield* useTestServer();
+    let incoming = yield* server;
+
+    let client = yield* connect(port);
+    let connection = (yield* incoming.next()).value;
+
+    let messages = yield* connection;
+    yield* client.send("hello from client");
+
+    let { value } = yield* messages.next();
+    expect(value).toMatchObject({ data: "hello from client" });
+  });
+
+  it("sends a message from a server connection to the client", function* () {
+    let { server, port } = yield* useTestServer();
+    let incoming = yield* server;
+
+    let client = yield* connect(port);
+    let connection = (yield* incoming.next()).value;
+
+    let clientMessages = yield* client;
+    yield* connection.send("hello from server");
+
+    let { value } = yield* clientMessages.next();
+    expect(value).toMatchObject({ data: "hello from server" });
+  });
+
+  it("completes a connection stream when its client disconnects", function* () {
+    let { server, port } = yield* useTestServer();
+    let incoming = yield* server;
+
+    let raw = new WebSocket(`ws://localhost:${port}`);
+    yield* useWebSocket<string>(() => raw);
+    let connection = (yield* incoming.next()).value;
+    let messages = yield* connection;
+
+    raw.close();
+
+    let event = yield* drain(messages);
+    expect(event.type).toEqual("close");
+    expect(event.wasClean).toEqual(true);
+  });
+
+  it("closes live client connections when the server is torn down", function* () {
+    let { httpServer, port } = yield* useHttp();
+    let accepted = createQueue<void, never>();
+
+    let serverTask = yield* spawn(function* () {
+      let server = yield* useWebSocketServer<string>(
+        () =>
+          new WebSocketServer({
+            server: httpServer,
+          }) as unknown as WebSocketServerLike,
+      );
+      let incoming = yield* server;
+      yield* incoming.next();
+      accepted.add();
+      yield* suspend();
+    });
+
+    let client = yield* connect(port);
+    let messages = yield* client;
+
+    // wait until the server has accepted the connection before tearing it down
+    yield* accepted.next();
+    yield* serverTask.halt();
+
+    let event = yield* drain(messages);
+    expect(event.type).toEqual("close");
+    expect(event.wasClean).toEqual(true);
+  });
+
+  it("surfaces each simultaneous client as a distinct connection", function* () {
+    let { server, port } = yield* useTestServer();
+    let incoming = yield* server;
+
+    // connect two clients, then read two buffered connections back out
+    let clientA = yield* connect(port);
+    let clientB = yield* connect(port);
+
+    let first = (yield* incoming.next()).value;
+    let second = (yield* incoming.next()).value;
+
+    expect(first).not.toBe(second);
+
+    // each connection receives only its own client's message, regardless of order
+    let firstMessages = yield* first;
+    let secondMessages = yield* second;
+
+    yield* clientA.send("A");
+    yield* clientB.send("B");
+
+    let received = [
+      (yield* firstMessages.next()).value?.data,
+      (yield* secondMessages.next()).value?.data,
+    ].sort();
+
+    expect(received).toEqual(["A", "B"]);
+  });
+});
+
+interface TestServer {
+  server: WebSocketServerResource<string>;
+  port: number;
+}
+
+function useTestServer(): Operation<TestServer> {
+  return resource(function* (provide) {
+    let { httpServer, port } = yield* useHttp();
+
+    let server = yield* useWebSocketServer<string>(
+      () =>
+        new WebSocketServer({
+          server: httpServer,
+        }) as unknown as WebSocketServerLike,
+    );
+
+    yield* provide({ server, port });
+  });
+}
+
+function useHttp(): Operation<{
+  httpServer: ReturnType<typeof createServer>;
+  port: number;
+}> {
+  return resource(function* (provide) {
+    let httpServer = createServer();
+
+    let listening = withResolvers<void>();
+    httpServer.listen(0, listening.resolve);
+    yield* listening.operation;
+
+    let port = (httpServer.address() as AddressInfo).port;
+
+    try {
+      yield* provide({ httpServer, port });
+    } finally {
+      let closed = withResolvers<void>();
+      httpServer.close(() => closed.resolve());
+      yield* closed.operation;
+    }
+  });
+}
+
+function* connect(port: number): Operation<WebSocketResource<string>> {
+  return yield* useWebSocket<string>(
+    () => new WebSocket(`ws://localhost:${port}`),
+  );
+}
+
+function* drain<T, TClose>(
+  subscription: Subscription<T, TClose>,
+): Operation<TClose> {
+  let next = yield* subscription.next();
+  while (!next.done) {
+    next = yield* subscription.next();
+  }
+  return next.value;
+}

--- a/websocket/server.test.ts
+++ b/websocket/server.test.ts
@@ -5,6 +5,7 @@ import {
   type Operation,
   type Subscription,
   createQueue,
+  ensure,
   resource,
   spawn,
   suspend,
@@ -13,20 +14,15 @@ import {
 import { expect } from "expect";
 import { WebSocketServer, type WebSocket as WsWebSocket } from "ws";
 
-import {
-  type WebSocketServerLike,
-  type WebSocketServerResource,
-  useWebSocketServer,
-} from "./server.ts";
+import { type WebSocketServerResource, useWebSocketServer } from "./server.ts";
 import { type WebSocketResource, useWebSocket } from "./websocket.ts";
 
 describe("WebSocketServer", () => {
   it("yields a connection and receives a message from the client", function* () {
     let { server, port } = yield* useTestServer();
-    let incoming = yield* server;
 
     let client = yield* connect(port);
-    let connection = (yield* incoming.next()).value;
+    let connection = (yield* server.next()).value;
 
     let messages = yield* connection;
     yield* client.send("hello from client");
@@ -37,10 +33,9 @@ describe("WebSocketServer", () => {
 
   it("sends a message from a server connection to the client", function* () {
     let { server, port } = yield* useTestServer();
-    let incoming = yield* server;
 
     let client = yield* connect(port);
-    let connection = (yield* incoming.next()).value;
+    let connection = (yield* server.next()).value;
 
     let clientMessages = yield* client;
     yield* connection.send("hello from server");
@@ -51,11 +46,10 @@ describe("WebSocketServer", () => {
 
   it("completes a connection stream when its client disconnects", function* () {
     let { server, port } = yield* useTestServer();
-    let incoming = yield* server;
 
     let raw = new WebSocket(`ws://localhost:${port}`);
     yield* useWebSocket<string>(() => raw);
-    let connection = (yield* incoming.next()).value;
+    let connection = (yield* server.next()).value;
     let messages = yield* connection;
 
     raw.close(4001, "goodbye");
@@ -76,10 +70,9 @@ describe("WebSocketServer", () => {
         () =>
           new WebSocketServer({
             server: httpServer,
-          }) as unknown as WebSocketServerLike,
+          }),
       );
-      let incoming = yield* server;
-      yield* incoming.next();
+      yield* server.next();
       accepted.add();
       yield* suspend();
     });
@@ -100,10 +93,9 @@ describe("WebSocketServer", () => {
 
   it("closes a connection with an explicit code and reason", function* () {
     let { server, port } = yield* useTestServer();
-    let incoming = yield* server;
 
     let client = yield* connect(port);
-    let connection = (yield* incoming.next()).value;
+    let connection = (yield* server.next()).value;
     let clientMessages = yield* client;
 
     yield* connection.close(4002, "custom");
@@ -116,12 +108,11 @@ describe("WebSocketServer", () => {
   it("buffers a connection that arrives before it is consumed", function* () {
     let { server, port } = yield* useTestServer();
 
-    // connect the client before subscribing to the server stream
+    // connect the client before reading any connection
     let client = yield* connect(port);
-    let incoming = yield* server;
 
-    // the connection was buffered while nobody was subscribed
-    let connection = (yield* incoming.next()).value;
+    // the connection was buffered before anybody read it
+    let connection = (yield* server.next()).value;
 
     let messages = yield* connection;
     yield* client.send("buffered hello");
@@ -138,15 +129,12 @@ describe("WebSocketServer", () => {
     let rawSockets = createQueue<WsWebSocket, never>();
     wss.on("connection", (ws) => rawSockets.add(ws));
 
-    let server = yield* useWebSocketServer<string>(
-      () => wss as unknown as WebSocketServerLike,
-    );
-    let incoming = yield* server;
+    let server = yield* useWebSocketServer<string>(() => wss);
     let serverErrors = yield* server.errors;
 
     // accept one client, then make its underlying socket error
     yield* connect(port);
-    yield* incoming.next();
+    yield* server.next();
     let raw = (yield* rawSockets.next()).value;
     raw.emit("error", new Error("boom"));
 
@@ -158,7 +146,7 @@ describe("WebSocketServer", () => {
 
     // and the server survives, serving a fresh client
     let client = yield* connect(port);
-    let connection = (yield* incoming.next()).value;
+    let connection = (yield* server.next()).value;
     let messages = yield* connection;
     yield* client.send("still alive");
     let { value } = yield* messages.next();
@@ -167,14 +155,13 @@ describe("WebSocketServer", () => {
 
   it("surfaces each simultaneous client as a distinct connection", function* () {
     let { server, port } = yield* useTestServer();
-    let incoming = yield* server;
 
     // connect two clients, then read two buffered connections back out
     let clientA = yield* connect(port);
     let clientB = yield* connect(port);
 
-    let first = (yield* incoming.next()).value;
-    let second = (yield* incoming.next()).value;
+    let first = (yield* server.next()).value;
+    let second = (yield* server.next()).value;
 
     expect(first).not.toBe(second);
 
@@ -207,7 +194,7 @@ function useTestServer(): Operation<TestServer> {
       () =>
         new WebSocketServer({
           server: httpServer,
-        }) as unknown as WebSocketServerLike,
+        }),
     );
 
     yield* provide({ server, port });
@@ -227,13 +214,13 @@ function useHttp(): Operation<{
 
     let port = (httpServer.address() as AddressInfo).port;
 
-    try {
-      yield* provide({ httpServer, port });
-    } finally {
+    yield* ensure(function* () {
       let closed = withResolvers<void>();
       httpServer.close(() => closed.resolve());
       yield* closed.operation;
-    }
+    });
+
+    yield* provide({ httpServer, port });
   });
 }
 

--- a/websocket/server.test.ts
+++ b/websocket/server.test.ts
@@ -1,5 +1,7 @@
+import { EventEmitter } from "node:events";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { timebox } from "@effectionx/timebox";
 import { describe, it } from "@effectionx/vitest";
 import {
   type Operation,
@@ -7,6 +9,8 @@ import {
   createQueue,
   ensure,
   resource,
+  scoped,
+  sleep,
   spawn,
   suspend,
   withResolvers,
@@ -14,7 +18,11 @@ import {
 import { expect } from "expect";
 import { WebSocketServer, type WebSocket as WsWebSocket } from "ws";
 
-import { type WebSocketServerResource, useWebSocketServer } from "./server.ts";
+import {
+  type WebSocketServerLike,
+  type WebSocketServerResource,
+  useWebSocketServer,
+} from "./server.ts";
 import { type WebSocketResource, useWebSocket } from "./websocket.ts";
 
 describe("WebSocketServer", () => {
@@ -89,6 +97,98 @@ describe("WebSocketServer", () => {
     expect(event.wasClean).toEqual(true);
     expect(event.code).toEqual(1001);
     expect(event.reason).toEqual("server shutting down");
+  });
+
+  it("closes every live connection when the server is torn down", function* () {
+    let { httpServer, port } = yield* useHttp();
+    let accepted = createQueue<void, never>();
+
+    let serverTask = yield* spawn(function* () {
+      let server = yield* useWebSocketServer<string>(
+        () => new WebSocketServer({ server: httpServer }),
+      );
+      yield* server.next();
+      yield* server.next();
+      accepted.add();
+      yield* suspend();
+    });
+
+    let clients = [yield* connect(port), yield* connect(port)];
+    let inboxes = [yield* clients[0], yield* clients[1]];
+
+    // both connections are established, so both belong to the live roster
+    yield* accepted.next();
+    yield* serverTask.halt();
+
+    for (let inbox of inboxes) {
+      let event = yield* drain(inbox);
+      expect(event.code).toEqual(1001);
+      expect(event.reason).toEqual("server shutting down");
+      expect(event.wasClean).toEqual(true);
+    }
+  });
+
+  it("does not complete teardown until the server has finished closing", function* () {
+    // this server never invokes its close callback until released, standing in
+    // for one with connections still winding down
+    let server = makeFakeServer({ deferClose: true });
+    let finished = createQueue<void, never>();
+
+    yield* spawn(function* () {
+      yield* scoped(function* () {
+        yield* useWebSocketServer<string>(() => server);
+      });
+      finished.add();
+    });
+
+    // the scope body is done, so teardown has asked the server to close
+    yield* sleep(0);
+    expect(server.closeCalls).toEqual(1);
+
+    // ...but teardown is still pending, because the callback has not fired
+    let early = yield* timebox(100, () => finished.next());
+    expect(early.timeout).toEqual(true);
+
+    server.releaseClose();
+
+    let late = yield* timebox(1_000, () => finished.next());
+    expect(late.timeout).toEqual(false);
+  });
+
+  it("bounds teardown when peers never answer the close handshake", function* () {
+    let server = makeFakeServer();
+    let sockets = [makeSilentSocket(), makeSilentSocket(), makeSilentSocket()];
+
+    let outcome = yield* timebox(2_000, () =>
+      scoped(function* () {
+        let connections = yield* useWebSocketServer<string>(() => server, {
+          closeTimeout: 10,
+        });
+        // emit once the accept loop is subscribed, which a real server's I/O
+        // guarantees but a hand-driven emitter does not
+        yield* spawn(function* () {
+          yield* sleep(0);
+          for (let socket of sockets) {
+            server.emit("connection", socket);
+          }
+        });
+        for (let _ of sockets) {
+          yield* connections.next();
+        }
+      }),
+    );
+
+    // leaving the scope closed all three without waiting on a reply that never
+    // comes, rather than hanging on the first silent peer
+    expect(outcome.timeout).toEqual(false);
+    expect(sockets.map((socket) => socket.closeCalls)).toEqual([1, 1, 1]);
+    // the going-away close won, so the scope-exit 1000 was a no-op
+    expect(sockets.map((socket) => socket.codes)).toEqual([
+      [1001],
+      [1001],
+      [1001],
+    ]);
+    expect(server.closeCalls).toEqual(1);
   });
 
   it("closes a connection with an explicit code and reason", function* () {
@@ -220,6 +320,60 @@ function useHttp(): Operation<{
 
     yield* provide({ httpServer, port });
   });
+}
+
+/**
+ * A server we drive by hand, so a test can hand {@link useWebSocketServer}
+ * sockets that a real peer would never produce.
+ */
+function makeFakeServer({ deferClose = false }: { deferClose?: boolean } = {}) {
+  let pending: (() => void) | undefined;
+  return Object.assign(new EventEmitter(), {
+    closeCalls: 0,
+    close(callback?: () => void) {
+      this.closeCalls += 1;
+      if (deferClose) {
+        pending = callback;
+      } else {
+        callback?.();
+      }
+    },
+    /** Fire a close callback that `deferClose` withheld. */
+    releaseClose() {
+      pending?.();
+    },
+  }) as unknown as EventEmitter &
+    WebSocketServerLike & { closeCalls: number; releaseClose(): void };
+}
+
+/**
+ * An accepted socket that is already open and never emits `open`, `close`, or
+ * `error` — a peer that takes a close frame and never answers it. `close()`
+ * only takes effect while the socket is open, like a real one, so a second
+ * close is the no-op the "first close wins" rule depends on.
+ */
+function makeSilentSocket() {
+  return {
+    readyState: WebSocket.OPEN as number,
+    binaryType: "blob" as BinaryType,
+    bufferedAmount: 0,
+    extensions: "",
+    protocol: "",
+    url: "ws://silent.test",
+    closeCalls: 0,
+    codes: [] as number[],
+    addEventListener() {},
+    removeEventListener() {},
+    send() {},
+    close(code?: number) {
+      if (this.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      this.readyState = WebSocket.CLOSING;
+      this.closeCalls += 1;
+      this.codes.push(code ?? 1000);
+    },
+  };
 }
 
 /**

--- a/websocket/server.test.ts
+++ b/websocket/server.test.ts
@@ -138,11 +138,9 @@ describe("WebSocketServer", () => {
     let raw = (yield* rawSockets.next()).value;
     raw.emit("error", new Error("boom"));
 
-    // the failure is surfaced on the errors stream, not thrown at the server.
-    // A socket failure surfaces as the DOM `error` event, whose message is the
-    // underlying error's message.
+    // the failure is surfaced on the errors stream, not thrown at the server
     let { value: error } = yield* serverErrors.next();
-    expect((error as ErrorEvent).message).toContain("boom");
+    expect(socketErrorEvent(error).message).toContain("boom");
 
     // and the server survives, serving a fresh client
     let client = yield* connect(port);
@@ -222,6 +220,18 @@ function useHttp(): Operation<{
 
     yield* provide({ httpServer, port });
   });
+}
+
+/**
+ * A socket failure throws the DOM `error` event, which is not an `Error`.
+ * Effection 4.1 and later box such a value in a `ThrownValueError` that keeps
+ * the original on `cause`, while earlier versions publish the event itself, and
+ * this package supports both.
+ */
+function socketErrorEvent(error: unknown): ErrorEvent {
+  return (
+    error instanceof Error && error.cause ? error.cause : error
+  ) as ErrorEvent;
 }
 
 function* connect(port: number): Operation<WebSocketResource<string>> {

--- a/websocket/server.test.ts
+++ b/websocket/server.test.ts
@@ -94,8 +94,23 @@ describe("WebSocketServer", () => {
     let event = yield* drain(messages);
     expect(event.type).toEqual("close");
     expect(event.wasClean).toEqual(true);
-    expect(event.code).toEqual(1000);
-    expect(event.reason).toEqual("released");
+    expect(event.code).toEqual(1001);
+    expect(event.reason).toEqual("server shutting down");
+  });
+
+  it("closes a connection with an explicit code and reason", function* () {
+    let { server, port } = yield* useTestServer();
+    let incoming = yield* server;
+
+    let client = yield* connect(port);
+    let connection = (yield* incoming.next()).value;
+    let clientMessages = yield* client;
+
+    yield* connection.close(4002, "custom");
+
+    let event = yield* drain(clientMessages);
+    expect(event.code).toEqual(4002);
+    expect(event.reason).toEqual("custom");
   });
 
   it("buffers a connection that arrives before it is consumed", function* () {

--- a/websocket/server.test.ts
+++ b/websocket/server.test.ts
@@ -58,11 +58,13 @@ describe("WebSocketServer", () => {
     let connection = (yield* incoming.next()).value;
     let messages = yield* connection;
 
-    raw.close();
+    raw.close(4001, "goodbye");
 
     let event = yield* drain(messages);
     expect(event.type).toEqual("close");
     expect(event.wasClean).toEqual(true);
+    expect(event.code).toEqual(4001);
+    expect(event.reason).toEqual("goodbye");
   });
 
   it("closes live client connections when the server is torn down", function* () {
@@ -92,6 +94,25 @@ describe("WebSocketServer", () => {
     let event = yield* drain(messages);
     expect(event.type).toEqual("close");
     expect(event.wasClean).toEqual(true);
+    expect(event.code).toEqual(1000);
+    expect(event.reason).toEqual("released");
+  });
+
+  it("buffers a connection that arrives before it is consumed", function* () {
+    let { server, port } = yield* useTestServer();
+
+    // connect the client before subscribing to the server stream
+    let client = yield* connect(port);
+    let incoming = yield* server;
+
+    // the connection was buffered while nobody was subscribed
+    let connection = (yield* incoming.next()).value;
+
+    let messages = yield* connection;
+    yield* client.send("buffered hello");
+
+    let { value } = yield* messages.next();
+    expect(value).toMatchObject({ data: "buffered hello" });
   });
 
   it("surfaces each simultaneous client as a distinct connection", function* () {

--- a/websocket/server.test.ts
+++ b/websocket/server.test.ts
@@ -115,8 +115,8 @@ describe("WebSocketServer", () => {
     yield* clientB.send("B");
 
     let received = [
-      (yield* firstMessages.next()).value?.data,
-      (yield* secondMessages.next()).value?.data,
+      ((yield* firstMessages.next()).value as MessageEvent<string>).data,
+      ((yield* secondMessages.next()).value as MessageEvent<string>).data,
     ].sort();
 
     expect(received).toEqual(["A", "B"]);

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -54,11 +54,16 @@ export interface WebSocketServerResource<T>
   extends Subscription<WebSocketResource<T>, never> {
   /**
    * A stream of errors raised by individual connections. A failing connection
-   * is isolated — it does not crash the server — and whatever it threw (for a
-   * socket failure, the DOM `error` event) is published here so you can observe
-   * per-connection failures by consuming this stream (rather than via a
-   * callback). It is lossy: errors emitted while nobody is subscribed are not
-   * buffered.
+   * is isolated — it does not crash the server — and whatever it threw is
+   * published here, so per-connection failures are observed by consuming this
+   * stream rather than through a callback. It is lossy: errors emitted while
+   * nobody is subscribed are not buffered.
+   *
+   * A socket failure throws the DOM `error` event, which is not an `Error`.
+   * Effection 4.1 and later box a thrown non-`Error` in a `ThrownValueError`
+   * whose `message` is the useless `String(event)` but whose `cause` is the
+   * event itself; earlier versions publish the event directly. Read `cause`
+   * first and fall back to the value.
    */
   errors: Stream<unknown, never>;
 }

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -1,4 +1,11 @@
-import { createQueue, each, resource, spawn } from "effection";
+import {
+  createQueue,
+  createSignal,
+  each,
+  resource,
+  scoped,
+  spawn,
+} from "effection";
 import type { Operation, Stream } from "effection";
 import { on, once } from "@effectionx/node";
 import type { EventEmitterLike } from "@effectionx/node";
@@ -33,7 +40,17 @@ export interface WebSocketServerLike extends EventEmitterLike {
  * when the resource passes out of scope.
  */
 export interface WebSocketServerResource<T>
-  extends Stream<WebSocketResource<T>, never> {}
+  extends Stream<WebSocketResource<T>, never> {
+  /**
+   * A stream of errors raised by individual connections. A failing connection
+   * is isolated — it does not crash the server — and whatever it threw (for a
+   * socket failure, the DOM `error` event) is published here so you can observe
+   * per-connection failures by consuming this stream (rather than via a
+   * callback). It is lossy: errors emitted while nobody is subscribed are not
+   * buffered.
+   */
+  errors: Stream<unknown, never>;
+}
 
 /**
  * Create a WebSocket server resource that yields a {@link Stream} of incoming
@@ -83,6 +100,7 @@ export function useWebSocketServer<T>(
     let server = create();
 
     let connections = createQueue<WebSocketResource<T>, never>();
+    let errors = createSignal<unknown, never>();
     let live = new Set<WebSocketResource<T>>();
 
     // crash the resource scope if the server itself errors, mirroring the
@@ -92,15 +110,34 @@ export function useWebSocketServer<T>(
       throw error;
     });
 
-    // accept connections: wrap each raw socket with the client resource and
-    // publish it. `useWebSocket` self-terminates when its socket closes, so no
-    // per-connection task or drain loop is needed — the wrapped connections live
-    // concurrently in this accept task's scope.
+    // accept connections. Each is handled in its own task wrapped in `scoped`,
+    // which is a real error boundary (its trap/delimiter contains a crash) — so
+    // a single socket erroring is isolated to that connection and published on
+    // `errors` instead of taking down the server. The connection is held open
+    // until its socket closes.
     yield* spawn(function* () {
       for (let [raw] of yield* each(on<[WebSocket]>(server, "connection"))) {
-        let connection = yield* useWebSocket<T>(() => raw);
-        live.add(connection);
-        connections.add(connection);
+        yield* spawn(function* () {
+          try {
+            yield* scoped(function* () {
+              let connection = yield* useWebSocket<T>(() => raw);
+              live.add(connection);
+              connections.add(connection);
+              try {
+                // stay alive until the socket closes
+                let subscription = yield* connection;
+                let next = yield* subscription.next();
+                while (!next.done) {
+                  next = yield* subscription.next();
+                }
+              } finally {
+                live.delete(connection);
+              }
+            });
+          } catch (error) {
+            errors.send(error);
+          }
+        });
         yield* each.next();
       }
     });
@@ -112,12 +149,14 @@ export function useWebSocketServer<T>(
         *[Symbol.iterator]() {
           return connections;
         },
+        errors,
       });
     } finally {
       // Compose a going-away shutdown: close live connections with 1001 before
       // releasing. The first close wins, so this takes precedence over each
-      // connection's scope-exit close (1000) as the accept task tears down.
-      for (let connection of live) {
+      // connection's scope-exit close (1000) as its task tears down. Snapshot
+      // the set because connections delete themselves from it as they close.
+      for (let connection of [...live]) {
         yield* connection.close(1001, "server shutting down");
       }
       server.close();

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -1,0 +1,140 @@
+import {
+  createQueue,
+  resource,
+  spawn,
+  useScope,
+  withResolvers,
+} from "effection";
+import type { Operation, Stream } from "effection";
+
+import { type WebSocketResource, useWebSocket } from "./websocket.ts";
+
+/**
+ * The minimal structural surface of a
+ * [`ws`](https://github.com/websockets/ws) `WebSocketServer` (or any
+ * compatible server) that {@link useWebSocketServer} needs.
+ *
+ * This is intentionally narrow so that the package never has to import a
+ * concrete server implementation and stays platform-agnostic. Because the
+ * `connection` event of the `ws` library yields its own `WebSocket` type
+ * rather than the DOM `WebSocket`, you may need to cast when passing a real
+ * server, e.g. `new WebSocketServer({ port }) as unknown as WebSocketServerLike`
+ * — mirroring the `ws as unknown as WebSocket` cast used with the client.
+ */
+export interface WebSocketServerLike {
+  on(event: "connection", listener: (socket: WebSocket) => void): void;
+  on(event: "error", listener: (error: Error) => void): void;
+  off(event: "connection", listener: (socket: WebSocket) => void): void;
+  off(event: "error", listener: (error: Error) => void): void;
+  close(callback?: () => void): void;
+}
+
+/**
+ * Handle to a WebSocket server consumed as an Effection {@link Stream}. Each
+ * value in the stream is a {@link WebSocketResource} representing a single
+ * client connection.
+ *
+ * A `WebSocketServerResource` has no explicit close method. The underlying
+ * server — and every live connection it produced — is automatically closed
+ * when the resource passes out of scope.
+ */
+export interface WebSocketServerResource<T>
+  extends Stream<WebSocketResource<T>, never> {}
+
+/**
+ * Create a WebSocket server resource that yields a {@link Stream} of incoming
+ * client connections. Each connection is a {@link WebSocketResource} — the very
+ * same full-duplex handle produced by {@link useWebSocket} on the client — so
+ * you receive messages by iterating it and reply with `yield* connection.send()`.
+ *
+ * The creation of the underlying server is delegated to a factory function,
+ * keeping this package free of any concrete server dependency. On Node this is
+ * typically the [`ws`](https://github.com/websockets/ws) `WebSocketServer`.
+ *
+ * Connections are buffered, so none are dropped between the moment the server
+ * starts listening and the moment you begin iterating. Since a stream is
+ * consumed sequentially, spawn a handler per connection to serve many clients
+ * concurrently:
+ *
+ * ```ts
+ * import { each, main, spawn } from "effection";
+ * import { WebSocketServer } from "ws";
+ * import { useWebSocketServer, type WebSocketServerLike } from "@effectionx/websocket";
+ *
+ * await main(function* () {
+ *   let server = yield* useWebSocketServer<string>(
+ *     () => new WebSocketServer({ port: 3000 }) as unknown as WebSocketServerLike,
+ *   );
+ *
+ *   for (let connection of yield* each(server)) {
+ *     yield* spawn(function* () {
+ *       for (let message of yield* each(connection)) {
+ *         yield* connection.send(`echo: ${message.data}`);
+ *         yield* each.next();
+ *       }
+ *     });
+ *     yield* each.next();
+ *   }
+ * });
+ * ```
+ *
+ * @param create - a function that constructs the underlying server object that
+ * this resource will manage
+ * @returns an operation yielding a {@link WebSocketServerResource}
+ */
+export function useWebSocketServer<T>(
+  create: () => WebSocketServerLike,
+): Operation<WebSocketServerResource<T>> {
+  return resource(function* (provide) {
+    let server = create();
+
+    let connections = createQueue<WebSocketResource<T>, never>();
+
+    // crash the resource scope if the server itself errors, mirroring the
+    // client's `throw yield* once(socket, "error")` behavior
+    let errored = withResolvers<Error>();
+    let onError = (error: Error) => errored.resolve(error);
+    server.on("error", onError);
+    yield* spawn(function* () {
+      throw yield* errored.operation;
+    });
+
+    let scope = yield* useScope();
+
+    // each connection lives as an independent task in this scope: it wraps the
+    // raw socket with the client resource, publishes it, and stays alive until
+    // the socket closes — at which point its scope (and the wrapped resource) is
+    // torn down instead of leaking a task per past connection.
+    let onConnection = (raw: WebSocket) => {
+      scope.run(function* () {
+        let connection = yield* useWebSocket<T>(() => raw);
+        connections.add(connection);
+
+        let subscription = yield* connection;
+        let next = yield* subscription.next();
+        while (!next.done) {
+          next = yield* subscription.next();
+        }
+      });
+    };
+    server.on("connection", onConnection);
+
+    try {
+      // a queue is itself a subscription; expose it as a stream whose
+      // subscription is the shared connection queue
+      yield* provide({
+        *[Symbol.iterator]() {
+          return connections;
+        },
+      });
+    } finally {
+      server.off("connection", onConnection);
+      server.off("error", onError);
+      // stop accepting new connections; the live connection tasks close their
+      // own sockets as this scope tears down. We don't await the close callback
+      // here because it can depend on those sockets closing, which happens as
+      // part of this same teardown.
+      server.close();
+    }
+  });
+}

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -1,9 +1,11 @@
 import { on, once } from "@effectionx/node";
 import type { EventEmitterLike } from "@effectionx/node";
 import {
+  all,
   createQueue,
   createSignal,
   each,
+  ensure,
   resource,
   scoped,
   spawn,
@@ -148,24 +150,27 @@ export function useWebSocketServer<T>(
       }
     });
 
-    try {
-      // a queue is itself a subscription; expose it as a stream whose
-      // subscription is the shared connection queue
-      yield* provide({
-        *[Symbol.iterator]() {
-          return connections;
-        },
-        errors,
-      });
-    } finally {
-      // Compose a going-away shutdown: close live connections with 1001 before
-      // releasing. The first close wins, so this takes precedence over each
-      // connection's scope-exit close (1000) as its task tears down. Snapshot
-      // the set because connections delete themselves from it as they close.
-      for (let connection of [...live]) {
-        yield* connection.close(1001, "server shutting down");
-      }
+    // Registered after the spawns so that it runs before they are halted: the
+    // going-away close has to land while each connection task is still alive.
+    yield* ensure(function* () {
+      // The first close wins, so 1001 takes precedence over the 1000 each
+      // connection sends as its own scope exits. Snapshot the set, because
+      // connections remove themselves from it as they close. Closing
+      // concurrently keeps a silent peer from serializing the whole shutdown
+      // into one close timeout apiece.
+      yield* all(
+        [...live].map((connection) =>
+          connection.close(1001, "server shutting down"),
+        ),
+      );
       server.close();
-    }
+    });
+
+    yield* provide({
+      *[Symbol.iterator]() {
+        return connections;
+      },
+      errors,
+    });
   });
 }

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -1,3 +1,5 @@
+import { on, once } from "@effectionx/node";
+import type { EventEmitterLike } from "@effectionx/node";
 import {
   createQueue,
   createSignal,
@@ -7,10 +9,12 @@ import {
   spawn,
 } from "effection";
 import type { Operation, Stream } from "effection";
-import { on, once } from "@effectionx/node";
-import type { EventEmitterLike } from "@effectionx/node";
 
-import { type WebSocketResource, useWebSocket } from "./websocket.ts";
+import {
+  type UseWebSocketOptions,
+  type WebSocketResource,
+  useWebSocket,
+} from "./websocket.ts";
 
 /**
  * The minimal structural surface of a
@@ -91,10 +95,12 @@ export interface WebSocketServerResource<T>
  *
  * @param create - a function that constructs the underlying server object that
  * this resource will manage
+ * @param options - options applied to every accepted WebSocket connection
  * @returns an operation yielding a {@link WebSocketServerResource}
  */
 export function useWebSocketServer<T>(
   create: () => WebSocketServerLike,
+  options: UseWebSocketOptions = {},
 ): Operation<WebSocketServerResource<T>> {
   return resource(function* (provide) {
     let server = create();
@@ -120,7 +126,7 @@ export function useWebSocketServer<T>(
         yield* spawn(function* () {
           try {
             yield* scoped(function* () {
-              let connection = yield* useWebSocket<T>(() => raw);
+              let connection = yield* useWebSocket<T>(() => raw, options);
               live.add(connection);
               connections.add(connection);
               try {

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -9,6 +9,7 @@ import {
   resource,
   scoped,
   spawn,
+  withResolvers,
 } from "effection";
 import type { Operation, Stream, Subscription } from "effection";
 
@@ -29,6 +30,10 @@ import {
  * concrete server implementation and stays platform-agnostic. A `ws`
  * `WebSocketServer` satisfies it structurally, so it can be passed directly
  * with no cast.
+ *
+ * Shutdown closes accepted sockets with `1001` ("going away"), which the full
+ * RFC 6455 range allows but the WHATWG API does not, so an implementation whose
+ * accepted sockets enforce the browser restriction needs a different code.
  */
 export interface WebSocketServerLike extends EventEmitterLike {
   close(callback?: () => void): void;
@@ -176,7 +181,11 @@ export function useWebSocketServer<T>(
           connection.close(1001, "server shutting down"),
         ),
       );
-      server.close();
+      // Wait for the listening socket to be released, so a resource that binds
+      // the same port after this one cannot lose the race with EADDRINUSE.
+      let closed = withResolvers<void>();
+      server.close(() => closed.resolve());
+      yield* closed.operation;
     });
 
     // A queue is already a subscription, so it is the handle itself.

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -83,6 +83,7 @@ export function useWebSocketServer<T>(
     let server = create();
 
     let connections = createQueue<WebSocketResource<T>, never>();
+    let live = new Set<WebSocketResource<T>>();
 
     // crash the resource scope if the server itself errors, mirroring the
     // client's `throw yield* once(socket, "error")` behavior
@@ -97,7 +98,9 @@ export function useWebSocketServer<T>(
     // concurrently in this accept task's scope.
     yield* spawn(function* () {
       for (let [raw] of yield* each(on<[WebSocket]>(server, "connection"))) {
-        connections.add(yield* useWebSocket<T>(() => raw));
+        let connection = yield* useWebSocket<T>(() => raw);
+        live.add(connection);
+        connections.add(connection);
         yield* each.next();
       }
     });
@@ -111,10 +114,12 @@ export function useWebSocketServer<T>(
         },
       });
     } finally {
-      // stop accepting new connections; the live connection tasks close their
-      // own sockets as this scope tears down. We don't await the close callback
-      // here because it can depend on those sockets closing, which happens as
-      // part of this same teardown.
+      // Compose a going-away shutdown: close live connections with 1001 before
+      // releasing. The first close wins, so this takes precedence over each
+      // connection's scope-exit close (1000) as the accept task tears down.
+      for (let connection of live) {
+        yield* connection.close(1001, "server shutting down");
+      }
       server.close();
     }
   });

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -1,5 +1,5 @@
-import { on, once } from "@effectionx/node";
-import type { EventEmitterLike } from "@effectionx/node";
+import { on, once } from "@effectionx/node/events";
+import type { EventEmitterLike } from "@effectionx/node/events";
 import {
   all,
   createQueue,

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -10,7 +10,7 @@ import {
   scoped,
   spawn,
 } from "effection";
-import type { Operation, Stream } from "effection";
+import type { Operation, Stream, Subscription } from "effection";
 
 import {
   type UseWebSocketOptions,
@@ -26,27 +26,32 @@ import {
  * `close` method.
  *
  * This is intentionally narrow so that the package never has to import a
- * concrete server implementation and stays platform-agnostic. Because the
- * `connection` event of the `ws` library yields its own `WebSocket` type
- * rather than the DOM `WebSocket`, you may need to cast when passing a real
- * server, e.g. `new WebSocketServer({ port }) as unknown as WebSocketServerLike`
- * — mirroring the `ws as unknown as WebSocket` cast used with the client.
+ * concrete server implementation and stays platform-agnostic. A `ws`
+ * `WebSocketServer` satisfies it structurally, so it can be passed directly
+ * with no cast.
  */
 export interface WebSocketServerLike extends EventEmitterLike {
   close(callback?: () => void): void;
 }
 
 /**
- * Handle to a WebSocket server consumed as an Effection {@link Stream}. Each
- * value in the stream is a {@link WebSocketResource} representing a single
- * client connection.
+ * Handle to a WebSocket server, consumed as an Effection
+ * {@link Subscription} of incoming client connections. Each value is a
+ * {@link WebSocketResource} representing a single client.
+ *
+ * This is deliberately a subscription rather than a {@link Stream}. A stream is
+ * stateless — subscribing to it is what allocates state — whereas a server
+ * starts listening and buffering connections the moment the resource is
+ * created, and every consumer draws from that one shared buffer. Handing back a
+ * subscription says so in the type: reading a connection consumes it, and there
+ * is no second independent replay of the connections that already arrived.
  *
  * A `WebSocketServerResource` has no explicit close method. The underlying
  * server — and every live connection it produced — is automatically closed
  * when the resource passes out of scope.
  */
 export interface WebSocketServerResource<T>
-  extends Stream<WebSocketResource<T>, never> {
+  extends Subscription<WebSocketResource<T>, never> {
   /**
    * A stream of errors raised by individual connections. A failing connection
    * is isolated — it does not crash the server — and whatever it threw (for a
@@ -59,38 +64,38 @@ export interface WebSocketServerResource<T>
 }
 
 /**
- * Create a WebSocket server resource that yields a {@link Stream} of incoming
- * client connections. Each connection is a {@link WebSocketResource} — the very
- * same full-duplex handle produced by {@link useWebSocket} on the client — so
- * you receive messages by iterating it and reply with `yield* connection.send()`.
+ * Create a WebSocket server resource that hands back a {@link Subscription} of
+ * incoming client connections. Each connection is a {@link WebSocketResource} —
+ * the very same full-duplex handle produced by {@link useWebSocket} on the
+ * client — so you receive messages by iterating it and reply with
+ * `yield* connection.send()`.
  *
  * The creation of the underlying server is delegated to a factory function,
  * keeping this package free of any concrete server dependency. On Node this is
  * typically the [`ws`](https://github.com/websockets/ws) `WebSocketServer`.
  *
- * Connections are buffered, so none are dropped between the moment the server
- * starts listening and the moment you begin iterating. Since a stream is
- * consumed sequentially, spawn a handler per connection to serve many clients
- * concurrently:
+ * Connections are buffered from the moment the resource is created, so none are
+ * dropped before you start reading. Because connections are read one at a time,
+ * spawn a handler per connection to serve many clients concurrently:
  *
  * ```ts
  * import { each, main, spawn } from "effection";
  * import { WebSocketServer } from "ws";
- * import { useWebSocketServer, type WebSocketServerLike } from "@effectionx/websocket";
+ * import { useWebSocketServer } from "@effectionx/websocket";
  *
  * await main(function* () {
- *   let server = yield* useWebSocketServer<string>(
- *     () => new WebSocketServer({ port: 3000 }) as unknown as WebSocketServerLike,
+ *   let connections = yield* useWebSocketServer<string>(
+ *     () => new WebSocketServer({ port: 3000 }),
  *   );
  *
- *   for (let connection of yield* each(server)) {
+ *   while (true) {
+ *     let { value: connection } = yield* connections.next();
  *     yield* spawn(function* () {
  *       for (let message of yield* each(connection)) {
  *         yield* connection.send(`echo: ${message.data}`);
  *         yield* each.next();
  *       }
  *     });
- *     yield* each.next();
  *   }
  * });
  * ```
@@ -107,9 +112,13 @@ export function useWebSocketServer<T>(
   return resource(function* (provide) {
     let server = create();
 
-    let connections = createQueue<WebSocketResource<T>, never>();
-    let errors = createSignal<unknown, never>();
+    // Two collections with different jobs: `accepted` is the delivery buffer,
+    // drained as the consumer reads, while `live` is the roster of still-open
+    // connections used to close them on shutdown. A connection sits in both
+    // until it is read, and stays in `live` long after it has left the buffer.
+    let accepted = createQueue<WebSocketResource<T>, never>();
     let live = new Set<WebSocketResource<T>>();
+    let errors = createSignal<unknown, never>();
 
     // crash the resource scope if the server itself errors, mirroring the
     // client's `throw yield* once(socket, "error")` behavior
@@ -118,11 +127,10 @@ export function useWebSocketServer<T>(
       throw error;
     });
 
-    // accept connections. Each is handled in its own task wrapped in `scoped`,
-    // which is a real error boundary (its trap/delimiter contains a crash) — so
-    // a single socket erroring is isolated to that connection and published on
-    // `errors` instead of taking down the server. The connection is held open
-    // until its socket closes.
+    // `scoped` contains a crash rather than letting it escalate, so one socket
+    // erroring is isolated to its own connection and reported on `errors`
+    // instead of taking down the server. Each connection is held open until its
+    // socket closes.
     yield* spawn(function* () {
       for (let [raw] of yield* each(on<[WebSocket]>(server, "connection"))) {
         yield* spawn(function* () {
@@ -130,7 +138,7 @@ export function useWebSocketServer<T>(
             yield* scoped(function* () {
               let connection = yield* useWebSocket<T>(() => raw, options);
               live.add(connection);
-              connections.add(connection);
+              accepted.add(connection);
               try {
                 // stay alive until the socket closes
                 let subscription = yield* connection;
@@ -166,10 +174,9 @@ export function useWebSocketServer<T>(
       server.close();
     });
 
+    // A queue is already a subscription, so it is the handle itself.
     yield* provide({
-      *[Symbol.iterator]() {
-        return connections;
-      },
+      next: () => accepted.next(),
       errors,
     });
   });

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -1,4 +1,4 @@
-import { createQueue, each, resource, spawn, useScope } from "effection";
+import { createQueue, each, resource, spawn } from "effection";
 import type { Operation, Stream } from "effection";
 import { on, once } from "@effectionx/node";
 import type { EventEmitterLike } from "@effectionx/node";
@@ -84,8 +84,6 @@ export function useWebSocketServer<T>(
 
     let connections = createQueue<WebSocketResource<T>, never>();
 
-    let scope = yield* useScope();
-
     // crash the resource scope if the server itself errors, mirroring the
     // client's `throw yield* once(socket, "error")` behavior
     yield* spawn(function* () {
@@ -93,22 +91,13 @@ export function useWebSocketServer<T>(
       throw error;
     });
 
-    // each incoming socket lives as an independent task in this scope: it wraps
-    // the raw socket with the client resource, publishes it, and stays alive
-    // until the socket closes — at which point its scope (and the wrapped
-    // resource) is torn down instead of leaking a task per past connection.
+    // accept connections: wrap each raw socket with the client resource and
+    // publish it. `useWebSocket` self-terminates when its socket closes, so no
+    // per-connection task or drain loop is needed — the wrapped connections live
+    // concurrently in this accept task's scope.
     yield* spawn(function* () {
       for (let [raw] of yield* each(on<[WebSocket]>(server, "connection"))) {
-        scope.run(function* () {
-          let connection = yield* useWebSocket<T>(() => raw);
-          connections.add(connection);
-
-          let subscription = yield* connection;
-          let next = yield* subscription.next();
-          while (!next.done) {
-            next = yield* subscription.next();
-          }
-        });
+        connections.add(yield* useWebSocket<T>(() => raw));
         yield* each.next();
       }
     });

--- a/websocket/server.ts
+++ b/websocket/server.ts
@@ -1,18 +1,16 @@
-import {
-  createQueue,
-  resource,
-  spawn,
-  useScope,
-  withResolvers,
-} from "effection";
+import { createQueue, each, resource, spawn, useScope } from "effection";
 import type { Operation, Stream } from "effection";
+import { on, once } from "@effectionx/node";
+import type { EventEmitterLike } from "@effectionx/node";
 
 import { type WebSocketResource, useWebSocket } from "./websocket.ts";
 
 /**
  * The minimal structural surface of a
  * [`ws`](https://github.com/websockets/ws) `WebSocketServer` (or any
- * compatible server) that {@link useWebSocketServer} needs.
+ * compatible server) that {@link useWebSocketServer} needs: an
+ * {@link EventEmitterLike} that emits `connection` and `error` events, plus a
+ * `close` method.
  *
  * This is intentionally narrow so that the package never has to import a
  * concrete server implementation and stays platform-agnostic. Because the
@@ -21,11 +19,7 @@ import { type WebSocketResource, useWebSocket } from "./websocket.ts";
  * server, e.g. `new WebSocketServer({ port }) as unknown as WebSocketServerLike`
  * — mirroring the `ws as unknown as WebSocket` cast used with the client.
  */
-export interface WebSocketServerLike {
-  on(event: "connection", listener: (socket: WebSocket) => void): void;
-  on(event: "error", listener: (error: Error) => void): void;
-  off(event: "connection", listener: (socket: WebSocket) => void): void;
-  off(event: "error", listener: (error: Error) => void): void;
+export interface WebSocketServerLike extends EventEmitterLike {
   close(callback?: () => void): void;
 }
 
@@ -90,34 +84,34 @@ export function useWebSocketServer<T>(
 
     let connections = createQueue<WebSocketResource<T>, never>();
 
-    // crash the resource scope if the server itself errors, mirroring the
-    // client's `throw yield* once(socket, "error")` behavior
-    let errored = withResolvers<Error>();
-    let onError = (error: Error) => errored.resolve(error);
-    server.on("error", onError);
-    yield* spawn(function* () {
-      throw yield* errored.operation;
-    });
-
     let scope = yield* useScope();
 
-    // each connection lives as an independent task in this scope: it wraps the
-    // raw socket with the client resource, publishes it, and stays alive until
-    // the socket closes — at which point its scope (and the wrapped resource) is
-    // torn down instead of leaking a task per past connection.
-    let onConnection = (raw: WebSocket) => {
-      scope.run(function* () {
-        let connection = yield* useWebSocket<T>(() => raw);
-        connections.add(connection);
+    // crash the resource scope if the server itself errors, mirroring the
+    // client's `throw yield* once(socket, "error")` behavior
+    yield* spawn(function* () {
+      let [error] = yield* once<[Error]>(server, "error");
+      throw error;
+    });
 
-        let subscription = yield* connection;
-        let next = yield* subscription.next();
-        while (!next.done) {
-          next = yield* subscription.next();
-        }
-      });
-    };
-    server.on("connection", onConnection);
+    // each incoming socket lives as an independent task in this scope: it wraps
+    // the raw socket with the client resource, publishes it, and stays alive
+    // until the socket closes — at which point its scope (and the wrapped
+    // resource) is torn down instead of leaking a task per past connection.
+    yield* spawn(function* () {
+      for (let [raw] of yield* each(on<[WebSocket]>(server, "connection"))) {
+        scope.run(function* () {
+          let connection = yield* useWebSocket<T>(() => raw);
+          connections.add(connection);
+
+          let subscription = yield* connection;
+          let next = yield* subscription.next();
+          while (!next.done) {
+            next = yield* subscription.next();
+          }
+        });
+        yield* each.next();
+      }
+    });
 
     try {
       // a queue is itself a subscription; expose it as a stream whose
@@ -128,8 +122,6 @@ export function useWebSocketServer<T>(
         },
       });
     } finally {
-      server.off("connection", onConnection);
-      server.off("error", onError);
       // stop accepting new connections; the live connection tasks close their
       // own sockets as this scope tears down. We don't await the close callback
       // here because it can depend on those sockets closing, which happens as

--- a/websocket/tsconfig.json
+++ b/websocket/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "../node"
     },
     {
+      "path": "../timebox"
+    },
+    {
       "path": "../vitest"
     }
   ]

--- a/websocket/tsconfig.json
+++ b/websocket/tsconfig.json
@@ -8,6 +8,9 @@
   "exclude": ["**/*.test.ts", "dist"],
   "references": [
     {
+      "path": "../node"
+    },
+    {
       "path": "../vitest"
     }
   ]

--- a/websocket/websocket.test.ts
+++ b/websocket/websocket.test.ts
@@ -6,6 +6,7 @@ import {
   createQueue,
   ensure,
   resource,
+  scoped,
   suspend,
   useScope,
   withResolvers,
@@ -63,7 +64,47 @@ describe("WebSocket", () => {
     expect(event.type).toEqual("close");
     expect(event.wasClean).toEqual(true);
   });
+
+  it("does not hang teardown when the peer never sends a close frame", function* () {
+    let socket = makeSilentSocket();
+
+    // `scoped` runs the body in a child scope and tears it down when the body
+    // returns — releasing the connection. Even though the socket never emits
+    // "close", the release must complete (bounded by the close timeout) rather
+    // than hang forever.
+    yield* scoped(function* () {
+      yield* useWebSocket(() => socket as unknown as WebSocket);
+    });
+
+    // reaching here means teardown completed; it also attempted the close
+    expect(socket.closeCalls).toEqual(1);
+  });
 });
+
+/**
+ * A minimal WebSocket stand-in that is already OPEN and never emits an "open",
+ * "close", or "error" event — used to prove teardown does not hang on a silent
+ * peer.
+ */
+function makeSilentSocket() {
+  return {
+    readyState: WebSocket.OPEN,
+    binaryType: "blob" as BinaryType,
+    bufferedAmount: 0,
+    extensions: "",
+    protocol: "",
+    url: "ws://silent.test",
+    closeCalls: 0,
+    // record listeners but never fire any event
+    addEventListener() {},
+    removeEventListener() {},
+    send() {},
+    close() {
+      // deliberately never fires a "close" event
+      this.closeCalls += 1;
+    },
+  };
+}
 
 interface TestSocket {
   close(): void;

--- a/websocket/websocket.test.ts
+++ b/websocket/websocket.test.ts
@@ -1,4 +1,5 @@
 import { createServer } from "node:http";
+import { timebox } from "@effectionx/timebox";
 import { describe, it } from "@effectionx/vitest";
 import {
   type Operation,
@@ -68,15 +69,15 @@ describe("WebSocket", () => {
   it("does not hang teardown when the peer never sends a close frame", function* () {
     let socket = makeSilentSocket();
 
-    // `scoped` runs the body in a child scope and tears it down when the body
-    // returns — releasing the connection. Even though the socket never emits
-    // "close", the release must complete (bounded by the close timeout) rather
-    // than hang forever.
-    yield* scoped(function* () {
-      yield* useWebSocket(() => socket as unknown as WebSocket);
-    });
+    let outcome = yield* timebox(100, () =>
+      scoped(function* () {
+        yield* useWebSocket(() => socket as unknown as WebSocket, {
+          closeTimeout: 0,
+        });
+      }),
+    );
 
-    // reaching here means teardown completed; it also attempted the close
+    expect(outcome.timeout).toEqual(false);
     expect(socket.closeCalls).toEqual(1);
   });
 });

--- a/websocket/websocket.test.ts
+++ b/websocket/websocket.test.ts
@@ -21,7 +21,7 @@ describe("WebSocket", () => {
 
     let subscription = yield* server.socket;
 
-    client.socket.send("hello from client");
+    yield* client.socket.send("hello from client");
 
     let { value } = yield* subscription.next();
 
@@ -33,7 +33,7 @@ describe("WebSocket", () => {
 
     let subscription = yield* client.socket;
 
-    server.socket.send("hello from server");
+    yield* server.socket.send("hello from server");
 
     let { value } = yield* subscription.next();
 

--- a/websocket/websocket.ts
+++ b/websocket/websocket.ts
@@ -50,7 +50,13 @@ export interface WebSocketResource<T>
    * released lets you choose the close code the peer observes; the automatic
    * scope-exit close then becomes a no-op.
    *
-   * @param code - a valid WebSocket close code (default `1000`)
+   * The code is handed to the underlying socket unchanged, so which codes are
+   * legal depends on the implementation. The WHATWG API accepts only `1000` and
+   * `3000`–`4999`, throwing `InvalidAccessError` for anything else, while a
+   * `ws` socket accepts the full RFC 6455 range — `1001` ("going away")
+   * included.
+   *
+   * @param code - a close code the underlying socket accepts (default `1000`)
    * @param reason - a close reason string (default `"released"`)
    */
   close(code?: number, reason?: string): Operation<void>;

--- a/websocket/websocket.ts
+++ b/websocket/websocket.ts
@@ -1,3 +1,4 @@
+import { timebox } from "@effectionx/timebox";
 import {
   createSignal,
   ensure,
@@ -8,13 +9,14 @@ import {
   withResolvers,
 } from "effection";
 import type { Operation, Stream } from "effection";
-import { timebox } from "@effectionx/timebox";
 
-/**
- * How long to wait for the peer's `close` handshake when a socket is released
- * before giving up and moving on, so a silent peer can never hang teardown.
- */
-const CLOSE_TIMEOUT_MS = 1000;
+export interface UseWebSocketOptions {
+  /**
+   * How many milliseconds to wait for the peer's close handshake before
+   * allowing teardown to continue. Defaults to `1000`.
+   */
+  closeTimeout?: number;
+}
 
 /**
  * Handle to a
@@ -79,13 +81,16 @@ export interface WebSocketResource<T>
  *
  * @param url - The URL of the target WebSocket server to connect to. The URL must use one of the following schemes: ws, wss, http, or https, and cannot include a URL fragment. If a relative URL is provided, it is relative to the base URL of the calling script. For more detail, see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#url
  *
- * @param prototol - A single string or an array of strings representing the sub-protocol(s) that the client would like to use, in order of preference. If it is omitted, an empty array is used by default, i.e. []. For more details, see
+ * @param protocolsOrOptions - A sub-protocol string, or resource options when
+ * no sub-protocol is needed
+ * @param options - Resource options when a sub-protocol is provided
  *
  * @returns an operation yielding a {@link WebSocketResource}
  */
 export function useWebSocket<T>(
   url: string,
-  protocols?: string,
+  protocolsOrOptions?: string | UseWebSocketOptions,
+  options?: UseWebSocketOptions,
 ): Operation<WebSocketResource<T>>;
 
 /**
@@ -116,10 +121,12 @@ export function useWebSocket<T>(
  *
  * ```
  * @param create - a function that will construct the underlying [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) object that this resource wil use
+ * @param options - Resource options
  * @returns an operation yielding a {@link WebSocketResource}
  */
 export function useWebSocket<T>(
   create: () => WebSocket,
+  options?: UseWebSocketOptions,
 ): Operation<WebSocketResource<T>>;
 
 /**
@@ -127,9 +134,17 @@ export function useWebSocket<T>(
  */
 export function useWebSocket<T>(
   url: string | (() => WebSocket),
-  protocols?: string,
+  protocolsOrOptions?: string | UseWebSocketOptions,
+  additionalOptions: UseWebSocketOptions = {},
 ): Operation<WebSocketResource<T>> {
   return resource(function* (provide) {
+    let protocols =
+      typeof protocolsOrOptions === "string" ? protocolsOrOptions : undefined;
+    let options =
+      typeof protocolsOrOptions === "object"
+        ? protocolsOrOptions
+        : additionalOptions;
+    let { closeTimeout = 1000 } = options;
     let socket =
       typeof url === "string" ? new WebSocket(url, protocols) : url();
 
@@ -158,7 +173,7 @@ export function useWebSocket<T>(
     // sees. On timeout we stop waiting rather than forcing a terminate.
     function* closeSocket(code: number, reason: string): Operation<void> {
       socket.close(code, reason);
-      yield* timebox(CLOSE_TIMEOUT_MS, () => closed);
+      yield* timebox(closeTimeout, () => closed);
     }
 
     // Don't hoist this above the spawns — teardown would hang waiting on

--- a/websocket/websocket.ts
+++ b/websocket/websocket.ts
@@ -167,7 +167,7 @@ export function useWebSocket<T>(
         get url() {
           return socket.url;
         },
-        *send(data) {
+        *send(data: WebSocketData): Operation<void> {
           socket.send(data);
         },
         [Symbol.iterator]: messages[Symbol.iterator],

--- a/websocket/websocket.ts
+++ b/websocket/websocket.ts
@@ -8,6 +8,13 @@ import {
   withResolvers,
 } from "effection";
 import type { Operation, Stream } from "effection";
+import { timebox } from "@effectionx/timebox";
+
+/**
+ * How long to wait for the peer's `close` handshake when a socket is released
+ * before giving up and moving on, so a silent peer can never hang teardown.
+ */
+const CLOSE_TIMEOUT_MS = 1000;
 
 /**
  * Handle to a
@@ -138,7 +145,9 @@ export function useWebSocket<T>(
     // `closed`.
     yield* ensure(function* () {
       socket.close(1000, "released");
-      yield* closed;
+      // Bound the wait for the peer's close handshake so a silent peer can't
+      // hang teardown; on timeout we simply stop waiting (no forced terminate).
+      yield* timebox(CLOSE_TIMEOUT_MS, () => closed);
       socket.removeEventListener("message", messages.send);
       socket.removeEventListener("close", messages.close);
     });

--- a/websocket/websocket.ts
+++ b/websocket/websocket.ts
@@ -24,8 +24,10 @@ const CLOSE_TIMEOUT_MS = 1000;
  * itself is a subscribale stream. When the socket is closed, the stream will
  * complete with a [`CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent)
  *
- * A WebSocketResource does not have an explicit close method. Rather, the underlying
- * socket will be automatically closed when the resource passes out of scope.
+ * The underlying socket is automatically closed when the resource passes out of
+ * scope (with code `1000` and reason `"released"`). For a different close code
+ * or reason — e.g. a `1001` "going away" on server shutdown — compose an
+ * explicit {@link WebSocketResource.close} before the resource is released.
  */
 export interface WebSocketResource<T>
   extends Stream<MessageEvent<T>, CloseEvent> {
@@ -39,6 +41,17 @@ export interface WebSocketResource<T>
   readonly readyState: number;
   readonly url: string;
   send(data: WebSocketData): Operation<void>;
+  /**
+   * Close the socket with an explicit code and reason, resolving once the close
+   * handshake completes (bounded by an internal timeout so a silent peer cannot
+   * hang). Because the first close wins, calling this before the resource is
+   * released lets you choose the close code the peer observes; the automatic
+   * scope-exit close then becomes a no-op.
+   *
+   * @param code - a valid WebSocket close code (default `1000`)
+   * @param reason - a close reason string (default `"released"`)
+   */
+  close(code?: number, reason?: string): Operation<void>;
 }
 
 /**
@@ -141,13 +154,18 @@ export function useWebSocket<T>(
       close(next.value);
     });
 
+    // The first close wins, so whoever calls this first picks the code the peer
+    // sees. On timeout we stop waiting rather than forcing a terminate.
+    function* closeSocket(code: number, reason: string): Operation<void> {
+      socket.close(code, reason);
+      yield* timebox(CLOSE_TIMEOUT_MS, () => closed);
+    }
+
     // Don't hoist this above the spawns — teardown would hang waiting on
     // `closed`.
     yield* ensure(function* () {
-      socket.close(1000, "released");
-      // Bound the wait for the peer's close handshake so a silent peer can't
-      // hang teardown; on timeout we simply stop waiting (no forced terminate).
-      yield* timebox(CLOSE_TIMEOUT_MS, () => closed);
+      // A no-op if the caller already closed with an explicit code via `close()`.
+      yield* closeSocket(1000, "released");
       socket.removeEventListener("message", messages.send);
       socket.removeEventListener("close", messages.close);
     });
@@ -178,6 +196,9 @@ export function useWebSocket<T>(
         },
         *send(data: WebSocketData): Operation<void> {
           socket.send(data);
+        },
+        *close(code = 1000, reason = "released"): Operation<void> {
+          yield* closeSocket(code, reason);
         },
         [Symbol.iterator]: messages[Symbol.iterator],
       }),

--- a/websocket/websocket.ts
+++ b/websocket/websocket.ts
@@ -31,7 +31,7 @@ export interface WebSocketResource<T>
   readonly protocol: string;
   readonly readyState: number;
   readonly url: string;
-  send(data: WebSocketData): void;
+  send(data: WebSocketData): Operation<void>;
 }
 
 /**
@@ -167,7 +167,9 @@ export function useWebSocket<T>(
         get url() {
           return socket.url;
         },
-        send: (data) => socket.send(data),
+        *send(data) {
+          socket.send(data);
+        },
         [Symbol.iterator]: messages[Symbol.iterator],
       }),
     ]);


### PR DESCRIPTION
# Motivation

The `@effectionx/websocket` package shipped only a **client** (`useWebSocket()`). There was no server counterpart, even though the package's own test file already implemented the full server-side mechanic by hand — a `ws` `WebSocketServer` firing `connection` events, each raw socket wrapped with `useWebSocket()`. This PR formalizes that pattern into a reusable server that pairs naturally with the existing client.

# Approach

**New `useWebSocketServer()`** (`websocket/server.ts`) — the server counterpart of `useWebSocket()`:

- Returns a `WebSocketServerResource<T>`: an Effection **`Subscription`** whose items are the **same full-duplex `WebSocketResource`** the client produces, so both sides share one handle type (iterate to receive, `yield* connection.send()` to reply).
- Reuses `useWebSocket()` to wrap each incoming socket.
- Buffers connections in a `createQueue`, so none are dropped between the server starting to listen and the consumer reading.
- Crashes the resource scope on a server `error`, mirroring the client.
- Isolates a failing connection with `scoped` so one bad socket does not take down the server, publishing what it threw on an `errors` stream.
- Auto-closes the server and every live connection when the resource passes out of scope, with close code `1001` ("going away").
- Takes a `() => WebSocketServerLike` **factory**, so the package never imports a concrete server implementation and stays platform-agnostic. A `ws` `WebSocketServer` satisfies the interface structurally and can be passed with no cast.

**`send` is now an `Operation`** — invoked as `yield* resource.send(...)` on both client and server, keeping the shared `WebSocketResource` symmetric and letting sends participate in structured concurrency.

**`close(code?, reason?)` is new on `WebSocketResource`**, bounded by a configurable `closeTimeout` (default `1000` ms) so a silent peer can never hang teardown.

> [!WARNING]
> **Breaking change:** `WebSocketResource.send()` changed from a synchronous `void` call to an `Operation`, so callers must now write `yield* socket.send(...)`. Version bumped `2.3.4 → 3.0.0`.
>
> **This one fails silently.** `send` is a generator method now, so an un-`yield*`ed `socket.send(data)` still typechecks — discarding a return value is legal — but the body never runs and the message is never sent. There is no type error and no runtime error to catch it, so every call site has to be updated by hand. Everything else in the release is additive: `useWebSocketServer`, `WebSocketServerLike`, `WebSocketServerResource`, `UseWebSocketOptions`, `close()`, and the new optional `useWebSocket` parameters.

**Dependencies:** this adds two workspace runtime dependencies — `@effectionx/node` (for `on`/`once` over the server's `EventEmitter`, imported via the `@effectionx/node/events` subpath) and `@effectionx/timebox` (to bound the close handshake). `ws` remains a devDependency for tests only.

**Also included:**
- `mod.ts` re-exports the server; updated client README/tests to `yield*` their sends.
- New `server.test.ts` (8 tests): connection delivery, message round-trips in both directions, close-propagation on client disconnect, server teardown closing live clients, explicit close code/reason, buffering before the first read, per-connection error isolation, and multiple simultaneous clients as distinct connections.
- README gains a "WebSocket Server" section with a full client↔server echo example.

## Why a `Subscription` rather than a `Stream`

Per review: a `Stream` is stateless — subscribing to it is what allocates state and starts the work. A server is the opposite. It begins listening and buffering the moment the resource is created, and every consumer draws from that one shared queue, so handing out a `Stream` implied an independent replay per subscriber that does not exist. Typing it as a `Subscription` states the real contract: reading a connection consumes it.

## Verification

- All **13 tests pass** (5 client + 8 server) — a real `ws` server against a real native `WebSocket` client, exercising the pairing end-to-end.
- Full repo suite green (393 passed), `tsc -b` and `tsc -p tsconfig.check.json` clean, `biome lint`/`format` clean, tsconfig references in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket server support for accepted connections and full-duplex messaging.
  * WebSocket sends now complete asynchronously, with explicit close controls and configurable close-handshake timeouts.
* **Documentation**
  * Refreshed Basic Usage with async-style sending.
  * Added a WebSocket Server guide covering messaging and lifecycle management.
* **Bug Fixes**
  * Improved shutdown reliability and isolated failures between connections.
* **Tests**
  * Added comprehensive WebSocket server coverage and updated messaging assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

