### PR TITLE
Trigger Website Rebuild On Merge

### DIFF
--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -1,0 +1,20 @@
+name: Trigger Effection Website Rebuild
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-effection-rebuild:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Trigger effection website rebuild
+        env:
+          GH_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+        run: |
+          gh workflow run www.yaml \
+            --repo thefrontside/effection

--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -6,10 +6,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   trigger-effection-rebuild:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency: 1
 
     steps:
       - name: Trigger effection website rebuild


### PR DESCRIPTION
# Motivation

Instead of manual button pressing. Trigger website rebuild on merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated GitHub Actions workflow to trigger website rebuilds via both manual runs and updates to the main branch.
  * Enabled coordinated, single-at-a-time execution with a defined timeout for reliable rebuild scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->