### PR TITLE
⬆️ Upgrade effection to 4.1.0

### DIFF
--- a/deno-deploy/deno.json
+++ b/deno-deploy/deno.json
@@ -4,6 +4,6 @@
   "exports": "./mod.ts",
   "license": "MIT",
   "imports": {
-    "effection": "npm:effection@^3"
+    "effection": "npm:effection@^4"
   }
 }

--- a/inline/mod.ts
+++ b/inline/mod.ts
@@ -1,12 +1,22 @@
 import { Ok } from "effection";
-import type { Effect, Operation, Result } from "effection";
+import type { Coroutine, Effect, Operation, Result } from "effection";
+
+/**
+ * A coroutine's `data.iterator` is what drives the routine, and swapping it is
+ * how `inline` splices an operation into the current frame. It is present at
+ * runtime, but was dropped from Effection's public `Coroutine` type in 4.0.3,
+ * so we restate it here.
+ */
+type RoutineData = Coroutine["data"] & {
+  iterator: EffectIterator;
+};
 
 export function inline<T>(operation: Operation<T>): Inline<T> {
   return {
     operation,
     description: `inline(${operation})`,
     enter(resolve, routine) {
-      let current = routine.data.iterator;
+      let current = (routine.data as RoutineData).iterator;
       if (isInlineIterator(current)) {
         current.stack.push(current.current);
         current.current = operation[Symbol.iterator]();

--- a/inline/mod.ts
+++ b/inline/mod.ts
@@ -2,8 +2,8 @@ import { Ok } from "effection";
 import type { Coroutine, Effect, Operation, Result } from "effection";
 
 /**
- * Still present at runtime, but dropped from Effection's public `Coroutine`
- * type in 4.0.3.
+ * Still present at runtime but intentionally omitted from Effection's public
+ * `Coroutine` because it's considered a private API.
  */
 type RoutineData = Coroutine["data"] & {
   iterator: EffectIterator;
@@ -20,9 +20,9 @@ export function inline<T>(operation: Operation<T>): Inline<T> {
         current.stack.push(current.current);
         current.current = operation[Symbol.iterator]();
       } else {
-        // `step()` reads the iterator from a closure variable that only this
-        // setter writes. Shadowing the property with a getter type checks, runs
-        // and does nothing.
+        // Don't turn this back into a `defineProperty`. `step()` reads the
+        // iterator from a closure variable that only this setter writes, so a
+        // getter type checks, runs, and silently does nothing.
         data.iterator = new InlineIterator(operation, current);
       }
       resolve(Ok() as Result<T>);

--- a/inline/mod.ts
+++ b/inline/mod.ts
@@ -16,16 +16,18 @@ export function inline<T>(operation: Operation<T>): Inline<T> {
     operation,
     description: `inline(${operation})`,
     enter(resolve, routine) {
-      let current = (routine.data as RoutineData).iterator;
+      let data = routine.data as RoutineData;
+      let current = data.iterator;
       if (isInlineIterator(current)) {
         current.stack.push(current.current);
         current.current = operation[Symbol.iterator]();
       } else {
-        let inlined = new InlineIterator(operation, current);
-        Object.defineProperty(routine.data, "iterator", {
-          get: () => inlined,
-          configurable: true,
-        });
+        // Assign through `data`'s own setter rather than redefining the
+        // property. Since effection 4.1, `Coroutine.step()` reads the iterator
+        // from a closure variable that only the setter writes, so shadowing the
+        // property with a getter leaves the routine driving the original
+        // iterator and `inline` silently does nothing.
+        data.iterator = new InlineIterator(operation, current);
       }
       resolve(Ok() as Result<T>);
       return (didExit) => didExit(Ok());

--- a/inline/mod.ts
+++ b/inline/mod.ts
@@ -2,10 +2,8 @@ import { Ok } from "effection";
 import type { Coroutine, Effect, Operation, Result } from "effection";
 
 /**
- * A coroutine's `data.iterator` is what drives the routine, and swapping it is
- * how `inline` splices an operation into the current frame. It is present at
- * runtime, but was dropped from Effection's public `Coroutine` type in 4.0.3,
- * so we restate it here.
+ * Still present at runtime, but dropped from Effection's public `Coroutine`
+ * type in 4.0.3.
  */
 type RoutineData = Coroutine["data"] & {
   iterator: EffectIterator;
@@ -22,11 +20,9 @@ export function inline<T>(operation: Operation<T>): Inline<T> {
         current.stack.push(current.current);
         current.current = operation[Symbol.iterator]();
       } else {
-        // Assign through `data`'s own setter rather than redefining the
-        // property. Since effection 4.1, `Coroutine.step()` reads the iterator
-        // from a closure variable that only the setter writes, so shadowing the
-        // property with a getter leaves the routine driving the original
-        // iterator and `inline` silently does nothing.
+        // `step()` reads the iterator from a closure variable that only this
+        // setter writes. Shadowing the property with a getter type checks, runs
+        // and does nothing.
         data.iterator = new InlineIterator(operation, current);
       }
       resolve(Ok() as Result<T>);

--- a/inline/package.json
+++ b/inline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/inline",
   "description": "Optimize deeply nested operations by collapsing yield delegation into a single iterator",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "main": "./dist/mod.js",
   "types": "./dist/mod.d.ts",
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@effectionx/bdd": "workspace:*",
     "@swc/core": "^1.15.0",
+    "effection": "^4",
     "esbuild": "^0.25.0",
     "expect": "^29"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 7.7.1
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
       expect:
         specifier: ^29
         version: 29.7.0
@@ -52,7 +52,7 @@ importers:
         version: link:../tinyexec
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
       generatorics:
         specifier: ^1
         version: 1.1.0
@@ -74,7 +74,7 @@ importers:
     devDependencies:
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   chain:
     devDependencies:
@@ -83,7 +83,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   context-api:
     dependencies:
@@ -96,7 +96,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   converge:
     dependencies:
@@ -109,7 +109,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   effect-ts:
     devDependencies:
@@ -121,7 +121,7 @@ importers:
         version: 3.19.14
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   fetch:
     dependencies:
@@ -134,7 +134,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   fs:
     dependencies:
@@ -147,7 +147,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   fx:
     devDependencies:
@@ -156,13 +156,9 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   inline:
-    dependencies:
-      effection:
-        specifier: ^3 || ^4
-        version: 4.0.2
     devDependencies:
       '@effectionx/bdd':
         specifier: workspace:*
@@ -170,6 +166,9 @@ importers:
       '@swc/core':
         specifier: ^1.15.0
         version: 1.15.11
+      effection:
+        specifier: ^4
+        version: 4.1.0
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
@@ -184,7 +183,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   middleware:
     devDependencies:
@@ -199,7 +198,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   process:
     dependencies:
@@ -233,7 +232,7 @@ importers:
         version: 6.0.6
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   raf:
     devDependencies:
@@ -245,7 +244,7 @@ importers:
         version: 1.2.0
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   scope-eval:
     devDependencies:
@@ -254,7 +253,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   signals:
     dependencies:
@@ -270,7 +269,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   state-api:
     dependencies:
@@ -283,7 +282,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   stream-helpers:
     dependencies:
@@ -305,7 +304,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   stream-yaml:
     dependencies:
@@ -321,7 +320,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   task-buffer:
     devDependencies:
@@ -336,13 +335,13 @@ importers:
         version: 8.1.5
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   test-adapter:
     devDependencies:
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   timebox:
     devDependencies:
@@ -351,7 +350,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   tinyexec:
     dependencies:
@@ -361,7 +360,7 @@ importers:
     devDependencies:
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   vitest:
     dependencies:
@@ -377,7 +376,7 @@ importers:
         version: 7.0.6
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
       vitest:
         specifier: ^4
         version: 4.1.0(@types/node@22.19.7)(vite@7.3.1(@types/node@22.19.7)(yaml@2.8.2))
@@ -417,7 +416,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
   websocket:
     devDependencies:
@@ -429,7 +428,7 @@ importers:
         version: 8.18.1
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
       ws:
         specifier: ^8
         version: 8.19.0
@@ -454,7 +453,7 @@ importers:
         version: link:../vitest
       effection:
         specifier: ^4
-        version: 4.0.2
+        version: 4.1.0
 
 packages:
 
@@ -1188,8 +1187,8 @@ packages:
   effect@3.19.14:
     resolution: {integrity: sha512-3vwdq0zlvQOxXzXNKRIPKTqZNMyGCdaFUBfMPqpsyzZDre67kgC1EEHDV4EoQTovJ4w5fmJW756f86kkuz7WFA==}
 
-  effection@4.0.2:
-    resolution: {integrity: sha512-O8WMGP10nPuJDwbNGILcaCNWS+CvDYjcdsUSD79nWZ+WtUQ8h1MEV7JJwCSZCSeKx8+TdEaZ/8r6qPTR2o/o8w==}
+  effection@4.1.0:
+    resolution: {integrity: sha512-/BJuaYhzDrvC/nrIW054z1itmCNjVNFtyv/J26xrS4pP2MLfm5TG8VFe5f4zl1oGcAoF1fq1GfDO+v0qx6URPw==}
     engines: {node: '>= 16'}
 
   es-module-lexer@2.0.0:
@@ -2063,7 +2062,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  effection@4.0.2: {}
+  effection@4.1.0: {}
 
   es-module-lexer@2.0.0: {}
 


### PR DESCRIPTION
## Why

Every package already declared `effection: "^4"`, but the lockfile was pinned at **4.0.2**, so the workspace never actually picked up 4.1. This refreshes the lockfile so all 28 workspace projects resolve **4.1.0**.

## What surfaced

Moving off 4.0.2 broke `@effectionx/inline` in two separate ways. Both are fixed here.

### 1. `inline` was silently a no-op on 4.1 (runtime bug)

`inline` splices an operation into the current frame by swapping the coroutine's iterator, which it did by redefining `iterator` on `routine.data` with a getter.

Up to 4.0.2 the reducer drove the routine by reading `routine.data.iterator` **through that getter**, so shadowing the property worked. Since the task/coroutine lifecycle unification, `Coroutine.step()` reads a closure variable that only `data`'s **setter** writes, and never consults the property:

```js
step() {
  ...
  return iterator.next(resumeWith.value);   // closure variable, not data.iterator
}
```

So the override was ignored and the routine kept driving the original iterator. `inline` did nothing. Fixed by assigning through the setter (`data.iterator = ...`) instead of redefining the property.

This was a real test failure, not a theoretical one — `inline.test.ts` was returning `undefined`/`NaN` where it expected values.

### 2. `Coroutine["data"].iterator` is no longer in the public types

It was dropped from the published `Coroutine` type in **4.0.3** — not 4.1 — and the repo never noticed because the lockfile hadn't moved. `mod.ts` now restates the field locally.

> **Worth raising upstream:** `inline` is built entirely on this field, and there is currently no supported way to reach it — it is absent from the public types *and* `step()` bypasses the accessor. If swapping a routine's iterator is meant to be part of the low-level `Effect`/`Coroutine` surface, it probably needs both a type and a stable path through `step()`.

### 3. `inline` had no devDependency on effection

Despite importing it in `mod.ts`, `inline.test.ts`, `esbuild.test.ts` and `swc.test.ts`. It was resolving through root hoisting. Now declared, matching every other package.

`deno-deploy/deno.json` was the last thing in the repo bound to effection 3 (`npm:effection@^3` → `^4`). That package is deprecated and excluded from the pnpm workspace, so nothing else about it changes.

## Version bumps

`@effectionx/inline` `0.0.1` → `0.0.2`.

## Verification

Run locally with the SWC wasm plugin built (`pnpm build`), matching CI:

- `pnpm install --frozen-lockfile` — clean; all 28 projects resolve `effection@4.1.0`
- `pnpm check`, `pnpm check:tsrefs`, `pnpm lint`, `pnpm fmt:check` — clean
- `pnpm test:node` — **34 passed**, 0 failed (was failing before the `inline` fix)
- `pnpm test` — **381 passed**, 6 skipped
- `pnpm test:matrix` — **all 10 combinations pass**, including effection 3.0.0 and 4.1.0

## Follow-ups (separate PRs)

First of three. Next: a policy documenting that async teardown must use `ensure()` rather than a `finally` block, then the migration of the 8 sites in this repo that currently `yield*` inside `finally`.