### PR TITLE
🤖 Require ensure() for async teardown

### DIFF
--- a/.policies/async-teardown.md
+++ b/.policies/async-teardown.md
@@ -1,0 +1,161 @@
+# Async Teardown Policy (Recommended)
+
+This document defines the recommended policy for cleanup code that needs to perform asynchronous work.
+
+## Core Principle
+
+**Teardown that needs `yield*` must go in `ensure()`, never in a `finally` block.**
+
+## The Rule
+
+| Case / Condition                                       | Required behavior                          |
+| ------------------------------------------------------ | ------------------------------------------- |
+| Cleanup is synchronous (`socket.close()`, `off(...)`)  | `finally` is fine; `ensure()` also fine     |
+| Cleanup needs `yield*` (awaiting close, draining, disposing) | Must use `ensure()`                   |
+| Mixed sync + async cleanup                             | Put the whole thing in `ensure()`           |
+
+### Why
+
+When a task is halted, Effection unwinds it by calling `iterator.return()` on the
+coroutine's generator. If a `finally` block then yields, the generator suspends *inside*
+the finally and reports `{ done: false }`. Effection resumes it with `iterator.next()` —
+**and that takes the frame out of return-mode.** The frame is no longer unwinding, so once
+the cleanup finishes, execution carries on past the operation that was being halted.
+
+This is the same defect Effection fixed inside `scoped()` in
+[thefrontside/effection#1185](https://github.com/thefrontside/effection/issues/1185):
+
+> `iter.return()` yielded the `destroy()` effects in scoped's finally, but the resume came
+> back as `iter.next()` — which takes the frame out of return-mode.
+
+`scoped()` re-arms the unwind explicitly. Ordinary user code has no way to do that, so the
+halt is simply lost.
+
+`ensure()` is not affected. It is implemented as a `resource()`, so its `finally` runs in
+its own task frame with no code after it, and it is driven by scope destruction — which
+`createTask` wraps in `critical()`, making it non-interruptible.
+
+Observed on effection 4.1.0, logging what runs after `task.halt()`:
+
+| Shape                                             | Result                              |
+| ------------------------------------------------- | ------------------------------------ |
+| `try/finally` + `yield*`, in a delegated helper   | `["cleanup", "outer-after"]` ← leaked |
+| `try/finally` + `yield*`, inside `call()`         | `["cleanup", "outer-after"]` ← leaked |
+| `try/finally` + `yield*`, inside `scoped()`       | `["cleanup", "outer-after"]` ← leaked |
+| `ensure()` + `yield*`                             | `["cleanup"]` ← correct               |
+
+## Examples
+
+### Compliant: Resource with async teardown
+
+```typescript
+function useConnection(url: string): Operation<Connection> {
+  return resource(function* (provide) {
+    let conn = yield* connect(url);
+
+    yield* ensure(function* () {
+      yield* conn.close();
+    });
+
+    yield* provide(conn);
+  });
+}
+```
+
+### Compliant: Sync teardown may stay in `finally`
+
+```typescript
+function useSocket(url: string): Operation<WebSocket> {
+  return resource(function* (provide) {
+    let socket = new WebSocket(url);
+    try {
+      yield* provide(socket);
+    } finally {
+      socket.close(); // no `yield*` — the frame never leaves return-mode
+    }
+  });
+}
+```
+
+### Non-Compliant: `yield*` inside `finally`
+
+```typescript
+function useConnection(url: string): Operation<Connection> {
+  return resource(function* (provide) {
+    let conn = yield* connect(url);
+    try {
+      yield* provide(conn);
+    } finally {
+      yield* conn.close(); // VIOLATION: disarms halt propagation for this frame
+    }
+  });
+}
+```
+
+## Gotchas
+
+These two are not obvious and are the usual source of a broken migration.
+
+### `ensure()` inside `call()` registers on the wrong scope
+
+`ensure()` registers a destructor on the **current** scope. `call()` does not create one —
+it delegates to the target's iterator in the same coroutine frame. So an `ensure()` inside
+`call(function* () { ... })` attaches to the *enclosing task's* scope and fires far too
+late.
+
+Use `scoped()` instead, which does establish a scope boundary:
+
+```typescript
+// WRONG — cleanup runs when the caller's task ends, not when this operation does
+call(function* () {
+  yield* ensure(cleanup);
+  return yield* work();
+});
+
+// RIGHT
+scoped(function* () {
+  yield* ensure(cleanup);
+  return yield* work();
+});
+```
+
+`resource(function* (provide) { ... })` bodies and `spawn(function* () { ... })` bodies
+each get their own scope, so `ensure()` is correct in those as-is.
+
+### Destructors run in reverse registration order
+
+Register the `ensure()` **exactly where the `try {` was** — after any `spawn()` calls the
+cleanup depends on, before the code the `try` wrapped. Registering last means running
+first, which preserves the ordering a `finally` gave you: cleanup runs while spawned
+children are still alive.
+
+## Verification Checklist
+
+Before marking a review complete, verify:
+
+- [ ] No `finally` block in the diff contains `yield*`
+- [ ] Async teardown is registered with `ensure()` before the code it guards
+- [ ] `ensure()` is not used directly inside `call()` — `scoped()` is used instead
+- [ ] `ensure()` is placed where the `try {` would have been, relative to `spawn()` calls
+- [ ] Halt behavior is tested, not just the happy path (see [Correctness Through Explicit Invariants](./correctness-invariants.md))
+
+## Common Mistakes
+
+| Mistake                                       | Fix                                                     |
+| --------------------------------------------- | -------------------------------------------------------- |
+| `finally { yield* thing.close(); }`           | `yield* ensure(function* () { yield* thing.close(); });` |
+| `ensure()` inside `call()`                    | Use `scoped()` — `call()` establishes no scope           |
+| `ensure()` registered before the `spawn()` its cleanup depends on | Register it where the `try {` was            |
+| Converting sync-only `finally` blocks         | Leave them; they are compliant                          |
+
+## Migration Stance
+
+Existing sync-only `finally` blocks are compliant and need no change. This policy applies
+to cleanup that performs asynchronous work.
+
+## Related Policies
+
+- [Structured Concurrency](./structured-concurrency.md) - Teardown is how task lifetimes stay explicit
+- [Small, Composable Units](./composable-units.md) - Uses `resource()` to isolate setup and teardown
+- [Correctness Through Explicit Invariants](./correctness-invariants.md) - Halt is a path that must be tested
+- [Policies Index](./index.md) - Add your new policy to the Policy Documents table

--- a/.policies/composable-units.md
+++ b/.policies/composable-units.md
@@ -46,17 +46,20 @@ function* readConfig(path: string): Operation<Config> {
 ### Compliant: Resource for setup/teardown
 
 ```typescript
-import { resource, type Operation } from "effection";
+import { ensure, resource, type Operation } from "effection";
 
 // Lifecycle encapsulated in resource
 function useDatabase(url: string): Operation<Database> {
   return resource(function* (provide) {
     let db = yield* connect(url);
-    try {
-      yield* provide(db);
-    } finally {
+
+    // async teardown goes in ensure(), never in finally
+    // see .policies/async-teardown.md
+    yield* ensure(function* () {
       yield* db.close();
-    }
+    });
+
+    yield* provide(db);
   });
 }
 
@@ -105,7 +108,8 @@ function* main(): Operation<void> {
     // More work...
     yield* moreWork(db);
   } finally {
-    // BAD: teardown mixed with business logic
+    // BAD: teardown mixed with business logic, and `yield*` in a finally
+    // disarms halt propagation — see .policies/async-teardown.md
     yield* db.close();
   }
 }
@@ -130,15 +134,16 @@ Before marking a review complete, verify:
 
 ## Common Mistakes
 
-| Mistake                          | Fix                                  |
-| -------------------------------- | ------------------------------------ |
-| Parse + fetch in one function    | Split: `fetchData()` + `parseData()` |
-| Inline try/finally for cleanup   | Use `resource()` pattern             |
-| "God operation" doing everything | Extract into composable steps        |
-| Copy-pasted operation logic      | Create reusable helper               |
+| Mistake                          | Fix                                        |
+| -------------------------------- | ------------------------------------------ |
+| Parse + fetch in one function    | Split: `fetchData()` + `parseData()`       |
+| Inline try/finally for cleanup   | Use `resource()` with `ensure()` teardown  |
+| "God operation" doing everything | Extract into composable steps              |
+| Copy-pasted operation logic      | Create reusable helper                     |
 
 ## Related Policies
 
 - [Structured Concurrency](./structured-concurrency.md) - Resource lifecycle patterns
+- [Async Teardown](./async-teardown.md) - Cleanup that yields belongs in `ensure()`
 - [Naming Consistency](./naming-consistency.md) - Clear names for extracted helpers
 - [Policies Index](./index.md) - Add your new policy to the Policy Documents table

--- a/.policies/composable-units.md
+++ b/.policies/composable-units.md
@@ -53,8 +53,6 @@ function useDatabase(url: string): Operation<Database> {
   return resource(function* (provide) {
     let db = yield* connect(url);
 
-    // async teardown goes in ensure(), never in finally
-    // see .policies/async-teardown.md
     yield* ensure(function* () {
       yield* db.close();
     });
@@ -108,8 +106,7 @@ function* main(): Operation<void> {
     // More work...
     yield* moreWork(db);
   } finally {
-    // BAD: teardown mixed with business logic, and `yield*` in a finally
-    // disarms halt propagation — see .policies/async-teardown.md
+    // BAD: teardown mixed with business logic
     yield* db.close();
   }
 }

--- a/.policies/deterministic-tests.md
+++ b/.policies/deterministic-tests.md
@@ -105,12 +105,12 @@ Before marking a review complete, verify:
 
 ## Common Mistakes
 
-| Mistake                          | Fix                                        |
-| -------------------------------- | ------------------------------------------ |
-| `sleep(100)` to wait for result  | Use `withResolvers()`, `when()`, or `is()` |
-| Asserting only on truthy/defined | Assert on specific values and states       |
-| No cleanup verification          | Add `finally` block and assert cleanup ran |
-| Missing halt path test           | Test both success and halt scenarios       |
+| Mistake                          | Fix                                                  |
+| -------------------------------- | ---------------------------------------------------- |
+| `sleep(100)` to wait for result  | Use `withResolvers()`, `when()`, or `is()`           |
+| Asserting only on truthy/defined | Assert on specific values and states                 |
+| No cleanup verification          | Record cleanup in a `finally`/`ensure()` and assert it ran |
+| Missing halt path test           | Test both success and halt scenarios                 |
 
 ## Related Policies
 

--- a/.policies/index.md
+++ b/.policies/index.md
@@ -14,14 +14,15 @@ This is the **single source of truth** for all policies in this repository.
 
 ### Established Policies
 
-| Policy                                                   | State       | Description                                                           |
-| -------------------------------------------------------- | ----------- | --------------------------------------------------------------------- |
-| [No-Sleep Test Synchronization](./no-sleep-test-sync.md) | Recommended | Use deterministic helpers instead of sleep() for test synchronization |
-| [Server-Is-The-Build](./server-is-the-build.md)          | Recommended | Prefer on-demand server generation over build-time scripts            |
-| [Stateless Stream Operations](./stateless-streams.md)    | Recommended | Use `*[Symbol.iterator]` pattern for reusable stream operations       |
-| [Version Bump](./version-bump.md)                        | Recommended | PRs changing package code must include a semantic version bump        |
-| [Package.json Metadata](./package-json-metadata.md)      | Strict      | Every published package must include a description field              |
-| [No Agent Marketing](./no-agent-marketing.md)            | Strict      | No AI tool promotional material in commits, PRs, issues, or comments |
+| Policy                                                   | State       | Description                                                            |
+| -------------------------------------------------------- | ----------- | ---------------------------------------------------------------------- |
+| [No-Sleep Test Synchronization](./no-sleep-test-sync.md) | Recommended | Use deterministic helpers instead of sleep() for test synchronization  |
+| [Server-Is-The-Build](./server-is-the-build.md)          | Recommended | Prefer on-demand server generation over build-time scripts             |
+| [Stateless Stream Operations](./stateless-streams.md)    | Recommended | Use `*[Symbol.iterator]` pattern for reusable stream operations        |
+| [Version Bump](./version-bump.md)                        | Recommended | PRs changing package code must include a semantic version bump         |
+| [Async Teardown](./async-teardown.md)                    | Recommended | Teardown that needs `yield*` must use `ensure()`, not a `finally` block |
+| [Package.json Metadata](./package-json-metadata.md)      | Strict      | Every published package must include a description field               |
+| [No Agent Marketing](./no-agent-marketing.md)            | Strict      | No AI tool promotional material in commits, PRs, issues, or comments   |
 
 ### Experimental Policies (cowboyd Review Patterns)
 
@@ -51,7 +52,8 @@ Lifecycle & Concurrency (core)
 ├── Structured Concurrency ──────► foundation for lifecycle patterns
 │   ├── Deterministic Tests ─────► extends No-Sleep Test Sync
 │   ├── Correctness Invariants ──► tests success/error/halt paths
-│   └── Composable Units ────────► uses resource() for teardown
+│   ├── Composable Units ────────► uses resource() for teardown
+│   └── Async Teardown ──────────► ensure() for cleanup that yields
 
 API Design (balance)
 ├── Minimal APIs ◄──── tension ────► Ergonomics

--- a/.policies/structured-concurrency.md
+++ b/.policies/structured-concurrency.md
@@ -14,7 +14,8 @@ This document defines the experimental policy for structured concurrency pattern
 | Consuming Promises          | Use `until(promise)` to integrate with scope lifecycle                        |
 | Cancellation-sensitive APIs | Use `useAbortSignal()` and pass to fetch/timers                               |
 | Background tasks            | Must be spawned children, not detached                                        |
-| Cleanup logic               | Must be in `finally` blocks or resource teardown                              |
+| Synchronous cleanup         | Must be in a `finally` block or resource teardown                             |
+| Cleanup that needs `yield*` | Must be in `ensure()` — see [Async Teardown](./async-teardown.md)             |
 
 ## Examples
 
@@ -64,6 +65,10 @@ function useConnection(url: string): Operation<Connection> {
 }
 ```
 
+`ws.close()` is synchronous, so a `finally` block is fine here. Teardown that needs
+`yield*` must use `ensure()` instead — a `yield*` inside `finally` disarms halt
+propagation for that frame. See [Async Teardown](./async-teardown.md).
+
 ### Non-Compliant: Fire-and-forget spawn
 
 ```typescript
@@ -89,20 +94,23 @@ Before marking a review complete, verify:
 - [ ] All `spawn()` calls are yielded (`yield* spawn(...)`)
 - [ ] Promises are wrapped with `until()` for scope integration
 - [ ] Fetch calls use `useAbortSignal()` for cancellation
-- [ ] Resources have teardown in `finally` blocks
+- [ ] Resources have teardown — `finally` for sync cleanup, `ensure()` when it yields
+- [ ] No `finally` block in the diff contains `yield*`
 - [ ] No fire-and-forget `void asyncFn()` patterns
 
 ## Common Mistakes
 
-| Mistake                         | Fix                                           |
-| ------------------------------- | --------------------------------------------- |
-| `spawn(op)` without yield       | `yield* spawn(op)` to attach to scope         |
-| `await fetch(url)` in operation | `yield* until(fetch(url, { signal }))`        |
-| `setTimeout` without cleanup    | Use `sleep()` or wrap with `useAbortSignal()` |
-| Cleanup in `try` block          | Move to `finally` block for halt safety       |
+| Mistake                         | Fix                                              |
+| ------------------------------- | ------------------------------------------------ |
+| `spawn(op)` without yield       | `yield* spawn(op)` to attach to scope            |
+| `await fetch(url)` in operation | `yield* until(fetch(url, { signal }))`           |
+| `setTimeout` without cleanup    | Use `sleep()` or wrap with `useAbortSignal()`    |
+| Sync cleanup in `try` block     | Move to `finally` block for halt safety          |
+| `yield*` inside a `finally`     | Move it into `ensure()` — the halt is lost       |
 
 ## Related Policies
 
 - [No-Sleep Test Synchronization](./no-sleep-test-sync.md) - Deterministic test patterns for structured concurrency
+- [Async Teardown](./async-teardown.md) - Cleanup that yields belongs in `ensure()`
 - [Stateless Stream Operations](./stateless-streams.md) - Deferred execution pattern
 - [Policies Index](./index.md) - Add your new policy to the Policy Documents table

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,11 @@ When reviewing PRs:
 
 - Use structured concurrency (spawn, scope)
 - Resources must clean up properly on scope exit
+- **Teardown that needs `yield*` must go in `ensure()`, never in a `finally` block.**
+  When a task is halted Effection unwinds it with `iterator.return()`; if a `finally`
+  yields, the resume comes back as `iterator.next()`, which takes the frame out of
+  return-mode and the halt is lost. Synchronous cleanup in `finally` is fine.
+  See the [Async Teardown policy](.policies/async-teardown.md)
 - Prefer `Operation<T>` for async operations
 - Use `*[Symbol.iterator]` pattern for reusable stream operations (see Stateless Streams policy)
 - Avoid `sleep()` for test synchronization (see No-Sleep Test Sync policy)

--- a/bdd/README.md
+++ b/bdd/README.md
@@ -152,7 +152,8 @@ operations.
 ### ~~`afterEach`~~
 
 This package doesn't include `afterEach` because it's typically used for clean
-up. With Effection, clean up is done in `finally` block of the resource.
+up. With Effection, clean up is part of the resource: synchronous cleanup can go
+in a `finally` block, and anything that needs `yield*` belongs in `ensure()`.
 Consider creating a resource in beforeEach if you encounter a need for
 `afterEach`.
 

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -21,7 +21,7 @@ context automatically.
 import { combine } from "@effectionx/middleware";
 import type { Middleware } from "@effectionx/middleware";
 import type { Operation } from "effection";
-import { createContext } from "effection";
+import { createContext, ensure } from "effection";
 
 type Handler = Middleware<[Request], Operation<Response>>;
 
@@ -31,11 +31,12 @@ const DatabaseConnection = createContext<Connection>("database");
 const withDatabase: Handler = function* (args, next) {
   const conn = yield* connect(process.env.DATABASE_URL);
   yield* DatabaseConnection.set(conn);
-  try {
-    return yield* next(...args);
-  } finally {
+  // async teardown goes in ensure(), not finally — a `yield*` inside a
+  // `finally` disarms halt propagation for the frame
+  yield* ensure(function* () {
     yield* conn.close();
-  }
+  });
+  return yield* next(...args);
 };
 
 const withTransaction: Handler = function* (args, next) {

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -31,8 +31,6 @@ const DatabaseConnection = createContext<Connection>("database");
 const withDatabase: Handler = function* (args, next) {
   const conn = yield* connect(process.env.DATABASE_URL);
   yield* DatabaseConnection.set(conn);
-  // async teardown goes in ensure(), not finally — a `yield*` inside a
-  // `finally` disarms halt propagation for the frame
   yield* ensure(function* () {
     yield* conn.close();
   });


### PR DESCRIPTION
## Why

**`yield*` inside a `finally` is not safe.**

When a task is halted, Effection unwinds it by calling `iterator.return()` on the coroutine's generator. If the `finally` then yields, the generator suspends *inside* the finally and reports `{ done: false }`, so Effection resumes it with `iterator.next()` — **and that takes the frame out of return-mode**. The frame is no longer unwinding, so once cleanup finishes, execution carries on past the operation that was being torn down. The halt is lost.

This is the same defect Effection fixed inside `scoped()` in [thefrontside/effection#1185](https://github.com/thefrontside/effection/issues/1185):

> `iter.return()` yielded the `destroy()` effects in scoped's finally, but the resume came back as `iter.next()` — which takes the frame out of return-mode.

`scoped()` re-arms the unwind explicitly. Ordinary user code has no way to do that.

`ensure()` is unaffected: it is implemented as a `resource()`, so its `finally` runs in its own task frame with nothing after it, driven by scope destruction — which `createTask` wraps in `critical()`.

Measured on effection 4.1.0, logging what runs after `task.halt()`:

| Shape | Result |
|---|---|
| `try/finally` + `yield*`, in a delegated helper | `["cleanup", "outer-after"]` ← **leaked** |
| `try/finally` + `yield*`, inside `call()` | `["cleanup", "outer-after"]` ← **leaked** |
| `try/finally` + `yield*`, inside `scoped()` | `["cleanup", "outer-after"]` ← **leaked** |
| `ensure()` + `yield*` | `["cleanup"]` ← correct |

## What's here

**New policy** `.policies/async-teardown.md` (Recommended), registered in `.policies/index.md`. It documents the rule, the mechanism, and the two non-obvious gotchas that break a naive migration:

1. **`ensure()` inside `call()` registers on the wrong scope.** `call()` establishes no scope — it delegates to the target's iterator in the same coroutine frame — so the destructor attaches to the *enclosing task's* scope and fires far too late. Use `scoped()` there.
2. **Destructors run in reverse registration order.** Put the `ensure()` exactly where the `try {` was, so cleanup still runs while spawned children are alive.

**Corrections to docs that taught the opposite:**

- `.policies/composable-units.md` — the flagship `useDatabase()` example
- `middleware/README.md` — the Quick Start, the first code a reader sees
- `.policies/structured-concurrency.md` — rule table, checklist, mistakes table, plus a caveat on the canonical `resource()` example (which is sync-only and stays valid)
- `.policies/deterministic-tests.md` — cleanup-verification row
- `bdd/README.md` — the `afterEach` note
- `AGENTS.md` — `ensure()` was not mentioned anywhere in this repo's docs before this

**Sync-only `finally` is explicitly still compliant** and called out as such — nothing yields, so the frame never leaves return-mode. The ~32 sync sites in this repo are untouched.

## Version bumps

None — documentation only, per `.policies/version-bump.md`.

## Note on ordering

This PR states the policy; it does **not** make the codebase comply with it. The repo currently has 8 sites that `yield*` inside a `finally`. Those are migrated in the follow-up PR, kept separate so the policy text can be reviewed on its own merits.