### PR TITLE
🐛 Move async teardown from finally to ensure

### DIFF
--- a/chain/chain.test.ts
+++ b/chain/chain.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "expect";
-import type { Operation } from "effection";
+import { type Operation, sleep, spawn } from "effection";
 
 import { Chain } from "./mod.ts";
 
@@ -36,6 +36,23 @@ describe("chain", () => {
     } catch (_) {
       expect(didExecuteFinally).toEqual(true);
     }
+  });
+
+  it("does not resume the caller after a halt", function* () {
+    let sequence: string[] = [];
+
+    let task = yield* spawn(function* () {
+      yield* new Chain<void>(() => {}).finally(function* () {
+        sequence.push("teardown");
+        yield* sleep(5);
+      });
+      sequence.push("resumed after halt");
+    });
+
+    yield* sleep(1);
+    yield* task.halt();
+
+    expect(sequence).toEqual(["teardown"]);
   });
 
   it("can chain off of an existing operation", function* () {

--- a/chain/mod.ts
+++ b/chain/mod.ts
@@ -1,5 +1,5 @@
-import type { Operation, WithResolvers } from "effection";
-import { call, withResolvers } from "effection";
+import type { Operation, Result, WithResolvers } from "effection";
+import { call, ensure, Err, Ok, spawn, withResolvers } from "effection";
 
 /**
  * Resolve a Chain
@@ -113,14 +113,27 @@ function from<T>(source: Operation<T>): From<T> {
         }),
       ),
 
+    // We can't use `scoped` here to prevent losing the halt on effection
+    // older than 4.1, where its own async teardown has that bug.
     finally: (fn) =>
       from(
-        call(function* () {
-          try {
-            return yield* chain;
-          } finally {
-            yield* fn();
+        call(function* (): Operation<T> {
+          let task = yield* spawn(function* (): Operation<Result<T>> {
+            yield* ensure(fn);
+            // Don't let this throw to prevent the error from also reaching
+            // the owning scope, where it escapes the caller's catch and
+            // tears the scope down.
+            try {
+              return Ok(yield* chain);
+            } catch (error) {
+              return Err(error as Error);
+            }
+          });
+          let result = yield* task;
+          if (result.ok) {
+            return result.value;
           }
+          throw result.error;
         }),
       ),
   };

--- a/chain/package.json
+++ b/chain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/chain",
   "description": "Promise-like chaining with then/catch/finally for Effection operations",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "keywords": ["interop"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/effect-ts/effect-runtime.ts
+++ b/effect-ts/effect-runtime.ts
@@ -1,5 +1,5 @@
 import { type Effect, Exit, Layer, ManagedRuntime } from "effect";
-import { type Operation, action, resource, until } from "effection";
+import { type Operation, action, ensure, resource, until } from "effection";
 
 /**
  * A runtime for executing Effect programs inside Effection operations.
@@ -174,9 +174,7 @@ export function makeEffectRuntime<R = never>(
       });
     };
 
-    try {
-      yield* provide({ run, runExit });
-    } finally {
+    yield* ensure(function* () {
       const active = Array.from(pending);
       for (const execution of active) {
         execution.abort();
@@ -184,6 +182,8 @@ export function makeEffectRuntime<R = never>(
 
       yield* until(Promise.all(active.map((execution) => execution.settled)));
       yield* until(managedRuntime.dispose());
-    }
+    });
+
+    yield* provide({ run, runExit });
   });
 }

--- a/effect-ts/package.json
+++ b/effect-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/effect-ts",
   "description": "Bidirectional interop between Effect-TS and Effection",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "keywords": ["interop"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/jsonl-store/jsonl.ts
+++ b/jsonl-store/jsonl.ts
@@ -17,6 +17,7 @@ import {
   createChannel,
   createQueue,
   each,
+  ensure,
   resource,
   spawn,
 } from "effection";
@@ -127,15 +128,16 @@ export class JSONLStore implements Store {
 
       yield* spawn(function* () {
         const reader = lines.getReader();
-        try {
-          while (true) {
-            const { done, value } = yield* call(() => reader.read());
-            yield* channel.send(value as T);
-            if (done) break;
-          }
-        } finally {
+
+        yield* ensure(function* () {
           reader.releaseLock();
           yield* channel.close();
+        });
+
+        while (true) {
+          const { done, value } = yield* call(() => reader.read());
+          yield* channel.send(value as T);
+          if (done) break;
         }
       });
 

--- a/jsonl-store/package.json
+++ b/jsonl-store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/jsonl-store",
   "description": "Streaming JSONL document store with glob-based file selection",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "keywords": ["streams", "io"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/tinyexec/package.json
+++ b/tinyexec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/tinyexec",
   "description": "Lightweight process execution wrapper around tinyexec",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/tinyexec/tinyexec.ts
+++ b/tinyexec/tinyexec.ts
@@ -1,4 +1,11 @@
-import { call, type Operation, resource, type Stream, stream } from "effection";
+import {
+  call,
+  ensure,
+  type Operation,
+  resource,
+  type Stream,
+  stream,
+} from "effection";
 import { type KillSignal, type Options, type Output, x as $x } from "tinyexec";
 
 /**
@@ -49,10 +56,10 @@ export function x(
       },
     };
 
-    try {
-      yield* provide(tinyproc);
-    } finally {
+    yield* ensure(function* () {
       yield* tinyproc.kill();
-    }
+    });
+
+    yield* provide(tinyproc);
   });
 }

--- a/watch/package.json
+++ b/watch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/watch",
   "description": "Run commands and restart them gracefully when source files change",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/main.js",

--- a/watch/watch.ts
+++ b/watch/watch.ts
@@ -5,6 +5,7 @@ import {
   call,
   createChannel,
   createSignal,
+  ensure,
   Err,
   Ok,
   type Operation,
@@ -158,11 +159,9 @@ export function watch(options: WatchOptions): Stream<Start, never> {
       }
     });
 
-    try {
-      yield* provide(subscription);
-    } finally {
-      yield* until(watcher.close());
-    }
+    yield* ensure(() => until(watcher.close()));
+
+    yield* provide(subscription);
   });
 }
 

--- a/websocket/package.json
+++ b/websocket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/websocket",
   "description": "WebSocket client with stream-based message handling and automatic cleanup",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "keywords": ["io", "streams"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/websocket/websocket.test.ts
+++ b/websocket/websocket.test.ts
@@ -4,6 +4,7 @@ import {
   type Operation,
   type Subscription,
   createQueue,
+  ensure,
   resource,
   suspend,
   useScope,
@@ -114,9 +115,7 @@ function useTestingPair(
 
     let remote = next.value;
 
-    try {
-      yield* provide([local, remote]);
-    } finally {
+    yield* ensure(function* () {
       // Close websocket connections first so httpServer can close
       local.close();
       remote.close();
@@ -124,7 +123,9 @@ function useTestingPair(
       const closed = withResolvers<void>();
       httpServer.close(() => closed.resolve());
       yield* closed.operation;
-    }
+    });
+
+    yield* provide([local, remote]);
   });
 }
 

--- a/websocket/websocket.ts
+++ b/websocket/websocket.ts
@@ -1,5 +1,6 @@
 import {
   createSignal,
+  ensure,
   once,
   race,
   resource,
@@ -133,41 +134,43 @@ export function useWebSocket<T>(
       close(next.value);
     });
 
-    try {
-      socket.addEventListener("message", messages.send);
-      socket.addEventListener("close", messages.close);
-
-      yield* race([
-        closed,
-        provide({
-          get binaryType() {
-            return socket.binaryType;
-          },
-          get bufferedAmmount() {
-            return socket.bufferedAmount;
-          },
-          get extensions() {
-            return socket.extensions;
-          },
-          get protocol() {
-            return socket.protocol;
-          },
-          get readyState() {
-            return socket.readyState;
-          },
-          get url() {
-            return socket.url;
-          },
-          send: (data) => socket.send(data),
-          [Symbol.iterator]: messages[Symbol.iterator],
-        }),
-      ]);
-    } finally {
+    // Don't hoist this above the spawns — teardown would hang waiting on
+    // `closed`.
+    yield* ensure(function* () {
       socket.close(1000, "released");
       yield* closed;
       socket.removeEventListener("message", messages.send);
       socket.removeEventListener("close", messages.close);
-    }
+    });
+
+    socket.addEventListener("message", messages.send);
+    socket.addEventListener("close", messages.close);
+
+    yield* race([
+      closed,
+      provide({
+        get binaryType() {
+          return socket.binaryType;
+        },
+        get bufferedAmmount() {
+          return socket.bufferedAmount;
+        },
+        get extensions() {
+          return socket.extensions;
+        },
+        get protocol() {
+          return socket.protocol;
+        },
+        get readyState() {
+          return socket.readyState;
+        },
+        get url() {
+          return socket.url;
+        },
+        send: (data) => socket.send(data),
+        [Symbol.iterator]: messages[Symbol.iterator],
+      }),
+    ]);
   });
 }
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/worker",
   "description": "Web Worker integration with two-way messaging and graceful shutdown",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "keywords": ["platform"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -4,6 +4,7 @@ import {
   type Operation,
   type Result,
   createChannel,
+  ensure,
   on,
   once,
   resource,
@@ -215,96 +216,7 @@ export function useWorker<TSend, TRecv, TReturn, TData>(
       throw event.error;
     });
 
-    try {
-      worker.postMessage({
-        type: "init",
-        data: options?.data,
-      });
-
-      yield* provide({
-        *send(value) {
-          const response = yield* useChannelResponse<TRecv>();
-          worker.postMessage(
-            {
-              type: "send",
-              value,
-              response: response.port,
-            },
-            [response.port],
-          );
-          const result = yield* response;
-          if (result.ok) {
-            return result.value;
-          }
-          throw errorFromSerialized("Worker handler failed", result.error);
-        },
-
-        *forEach<WRequest, WResponse, WProgress = never>(
-          fn: (
-            request: WRequest,
-            ctx: ForEachContext<WProgress>,
-          ) => Operation<WResponse>,
-        ): Operation<TReturn> {
-          // Prevent calling forEach more than once
-          if (forEachCompleted) {
-            throw new Error("forEach has already completed");
-          }
-
-          // Prevent concurrent forEach
-          if (forEachInProgress) {
-            throw new Error("forEach is already in progress");
-          }
-          forEachInProgress = true;
-
-          try {
-            // Iterate until channel closes (when worker sends "close")
-            let next = yield* requestSubscription.next();
-            while (!next.done) {
-              const request = next.value;
-              // Track handler errors - we forward to worker but also re-throw to host
-              let handlerError: Error | undefined;
-
-              // Create a task for this request and wait for it to complete
-              const task = yield* spawn(function* () {
-                const channelRequest = yield* useChannelRequest<
-                  WResponse,
-                  WProgress
-                >(request.response);
-                try {
-                  // Create context with progress method
-                  const ctx: ForEachContext<WProgress> = {
-                    progress: (data: WProgress) =>
-                      channelRequest.progress(data),
-                  };
-                  const result = yield* fn(request.value as WRequest, ctx);
-                  yield* channelRequest.resolve(result);
-                } catch (error) {
-                  // Forward error to worker so it knows the request failed
-                  yield* channelRequest.reject(error as Error);
-                  // Store error to re-throw after forwarding (don't swallow host errors)
-                  handlerError = error as Error;
-                }
-              });
-
-              // Wait for the handler to complete
-              yield* task;
-
-              // If the handler failed, stop processing and re-throw
-              if (handlerError) {
-                throw handlerError;
-              }
-              next = yield* requestSubscription.next();
-            }
-            return yield* outcome.operation;
-          } finally {
-            forEachInProgress = false;
-            forEachCompleted = true;
-          }
-        },
-
-        [Symbol.iterator]: outcome.operation[Symbol.iterator],
-      });
-    } finally {
+    yield* ensure(function* () {
       worker.postMessage({ type: "close" });
       if (!outcomeSettled) {
         while (!outcomeSettled) {
@@ -325,7 +237,95 @@ export function useWorker<TSend, TRecv, TReturn, TData>(
         }
       }
       yield* settled(outcome.operation);
-    }
+    });
+
+    worker.postMessage({
+      type: "init",
+      data: options?.data,
+    });
+
+    yield* provide({
+      *send(value) {
+        const response = yield* useChannelResponse<TRecv>();
+        worker.postMessage(
+          {
+            type: "send",
+            value,
+            response: response.port,
+          },
+          [response.port],
+        );
+        const result = yield* response;
+        if (result.ok) {
+          return result.value;
+        }
+        throw errorFromSerialized("Worker handler failed", result.error);
+      },
+
+      *forEach<WRequest, WResponse, WProgress = never>(
+        fn: (
+          request: WRequest,
+          ctx: ForEachContext<WProgress>,
+        ) => Operation<WResponse>,
+      ): Operation<TReturn> {
+        // Prevent calling forEach more than once
+        if (forEachCompleted) {
+          throw new Error("forEach has already completed");
+        }
+
+        // Prevent concurrent forEach
+        if (forEachInProgress) {
+          throw new Error("forEach is already in progress");
+        }
+        forEachInProgress = true;
+
+        try {
+          // Iterate until channel closes (when worker sends "close")
+          let next = yield* requestSubscription.next();
+          while (!next.done) {
+            const request = next.value;
+            // Track handler errors - we forward to worker but also re-throw to host
+            let handlerError: Error | undefined;
+
+            // Create a task for this request and wait for it to complete
+            const task = yield* spawn(function* () {
+              const channelRequest = yield* useChannelRequest<
+                WResponse,
+                WProgress
+              >(request.response);
+              try {
+                // Create context with progress method
+                const ctx: ForEachContext<WProgress> = {
+                  progress: (data: WProgress) => channelRequest.progress(data),
+                };
+                const result = yield* fn(request.value as WRequest, ctx);
+                yield* channelRequest.resolve(result);
+              } catch (error) {
+                // Forward error to worker so it knows the request failed
+                yield* channelRequest.reject(error as Error);
+                // Store error to re-throw after forwarding (don't swallow host errors)
+                handlerError = error as Error;
+              }
+            });
+
+            // Wait for the handler to complete
+            yield* task;
+
+            // If the handler failed, stop processing and re-throw
+            if (handlerError) {
+              throw handlerError;
+            }
+            next = yield* requestSubscription.next();
+          }
+          return yield* outcome.operation;
+        } finally {
+          forEachInProgress = false;
+          forEachCompleted = true;
+        }
+      },
+
+      [Symbol.iterator]: outcome.operation[Symbol.iterator],
+    });
   });
 }
 


### PR DESCRIPTION
Implements [#225](https://github.com/thefrontside/effectionx/pull/225)'s policy. Converts the **8 sites** in this repo that `yield*` inside a `finally`.

## Why

When a task is halted, Effection unwinds it with `iterator.return()`. If a `finally` then yields, the generator suspends inside it and reports `{ done: false }`, so Effection resumes with `iterator.next()` — **which takes the frame out of return-mode**. The halt is lost and execution carries on past the operation being torn down. Full mechanism in `.policies/async-teardown.md` (PR #225).

## chain was a real bug, not a theoretical one

Seven of the eight sites were preventative — their `finally` was the last thing in its frame, so nothing leaked yet.

**`chain.finally()` was actually broken.** It ran teardown in a `finally` inside `call()`, and `call()` establishes no scope, so the escape landed directly in the caller's frame. The new test in `chain.test.ts` fails against the old implementation with exactly the predicted symptom:

```
  Array [
    "teardown",
+   "resumed after halt",
  ]
```

## `spawn` + `ensure`, not `scoped` + `ensure`

`scoped` reads better and was my first implementation. It does not work here: **`scoped`'s own async teardown had this same defect until effection 4.1** ([#1185](https://github.com/thefrontside/effection/issues/1185) / [#1186](https://github.com/thefrontside/effection/pull/1186)), and `chain` declares `effection: "^3 || ^4"`. Measured:

| formulation | effection 4.0.2 | effection 4.1.0 |
|---|---|---|
| `scoped` + `ensure` | ❌ leaks | ✅ |
| `spawn` + `ensure` | ✅ | ✅ |
| `resource` + `ensure` | ✅ | ✅ |

`spawn` was chosen over `resource` because `resource` would defer teardown to the *caller's* scope exit, which is the wrong moment for `.finally()`.

The spawned task captures its outcome as a `Result` rather than throwing — an error thrown by a spawned task is *also* raised to its owning scope, which would report a rejected chain twice. That surfaced as a real failure in the existing "can have a finally" test before I added the capture.

## Placement rule

Each `ensure()` sits exactly where the `try {` used to open, because scope destructors run in **reverse registration order** — registering last means running first, preserving the ordering `finally` gave. In `websocket.ts` this is load-bearing: teardown does `yield* closed`, and `closed` is resolved by a task spawned above it.

## Sites

| Package | Shape |
|---|---|
| `tinyexec` | `try` wrapped only `provide` |
| `watch` | `try` wrapped only `provide` |
| `effect-ts` | `try` wrapped only `provide` |
| `websocket.test.ts` | test helper, same shape |
| `websocket` | `try` also wrapped setup + `race([closed, provide(...)])` |
| `worker` | `try` also wrapped the init `postMessage` |
| `jsonl-store` | inside a `spawn` body (own scope, plain `ensure`) |
| `chain` | not a resource — see above |

`inline.test.ts` uses a bare `yield inline(...)` in a `finally` deliberately, to exercise cleanup-during-halt for the inline protocol. Left alone.

**Sync-only `finally` blocks are untouched** (~32 of them) — nothing yields, so the frame never leaves return-mode.

## Version bumps

Patch: `chain` 0.2.4, `effect-ts` 0.1.6, `jsonl-store` 0.4.4, `tinyexec` 0.4.4, `watch` 0.4.6, `websocket` 2.3.4, `worker` 0.5.4.

## Verification

- `pnpm check`, `pnpm check:tsrefs`, `pnpm lint`, `pnpm fmt:check` — clean
- `pnpm test` — **382 passed** (+1 new regression test), 6 skipped
- `pnpm test:matrix` — **all 10 combinations pass**, including **effection 3.0.0**, which is what validates the `spawn` choice over `scoped`

Based on `main`, so it runs against effection 4.0.2 here; also verified against 4.1.0 locally. Independent of #224 and #225 — merges in any order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when operations halt during asynchronous finalization.
  * Ensured pending tasks complete teardown before runtimes and managed resources are disposed.
  * Improved reliability when closing processes, workers, watchers, data readers, and WebSocket connections.

* **Tests**
  * Added coverage confirming halted operations do not resume after cleanup completes.

* **Chores**
  * Published patch releases across the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->