### PR TITLE
🤖 Add a policy for writing code comments

### DIFF
--- a/.policies/code-comments.md
+++ b/.policies/code-comments.md
@@ -1,0 +1,138 @@
+# Code Comments Policy (Recommended)
+
+This document defines the recommended policy for writing comments in source code.
+
+## Core Principle
+
+**A comment must say something the code cannot.** If the code, its names, or a policy already says it, delete the comment.
+
+> **Note:** This policy is about comments addressed to the next contributor. For docs addressed to users of a package — JSDoc, examples, changelogs — see [Documentation Is Part of the API](./documentation.md).
+
+## The Rule
+
+| Situation                                             | Required behavior                                          |
+| ----------------------------------------------------- | ----------------------------------------------------------- |
+| Comment narrates what the adjacent code does          | Delete it                                                   |
+| Comment restates a rule from `.policies/`             | Delete it; the policy is the source of truth                |
+| Constraint whose violation fails silently             | Comment, leading with the instruction                       |
+| Deliberate deviation from a policy                    | Comment saying it is deliberate, and why                    |
+| Use of another package's private or untyped internals | Comment saying the omission is deliberate on their side     |
+
+## The Four Questions
+
+Before keeping a comment, answer all four:
+
+1. What is happening around the comment?
+2. What does the comment say now?
+3. What should it communicate?
+4. **Why do we need this comment at all?**
+
+The fourth question removes most comments. If the honest answer is "so the reader understands the code", the code should be clearer instead — see [Naming and Consistency](./naming-consistency.md). Keep the comment only when the answer names something outside the file: another package's behavior, an ordering constraint, a failure with no signal.
+
+## Writing Rules
+
+- **Lead with the instruction, not the mechanism.** A reader who must derive "so don't do X" from a paragraph of machinery will not derive it.
+- **State the consequence**, especially when the failure is silent — no type error, no exception, tests failing in a distant package.
+- **Prefer why over when.** Version numbers rot. They earn their place only when tied to a live constraint in the same package, such as its own peer dependency range, so the comment becomes deletable when that range moves.
+- **Verify before you assert.** If a comment claims something breaks, break it and confirm.
+- **Do not overstate.** An inflated blast radius reads as false to anyone who knows the system, and buries the accurate warning.
+
+## Examples
+
+### Non-Compliant: Mechanism without instruction
+
+```typescript
+// `step()` reads the iterator from a closure variable that only this setter
+// writes. Shadowing the property with a getter type checks, runs and does
+// nothing.
+data.iterator = new InlineIterator(operation, current);
+```
+
+### Compliant: Instruction first, mechanism behind it
+
+```typescript
+// Don't turn this back into a `defineProperty`. `step()` reads the iterator
+// from a closure variable that only this setter writes, so a getter type
+// checks, runs, and silently does nothing.
+data.iterator = new InlineIterator(operation, current);
+```
+
+### Non-Compliant: Says when, not why
+
+```typescript
+/**
+ * Still present at runtime, but dropped from Effection's public `Coroutine`
+ * type in 4.0.3.
+ */
+```
+
+### Compliant: Says why, and implies the risk
+
+```typescript
+/**
+ * Still present at runtime but intentionally omitted from Effection's public
+ * `Coroutine` because it's considered a private API.
+ */
+```
+
+### Non-Compliant: Restates a policy at the call site
+
+```typescript
+// async teardown goes in ensure(), never in finally — a `yield*` inside a
+// `finally` disarms halt propagation for the frame
+yield* ensure(function* () {
+  yield* conn.close();
+});
+```
+
+Covered by [Async Teardown](./async-teardown.md). The code already uses `ensure()`; repeating the rationale at every call site means it must be corrected in every call site.
+
+### Compliant: A local fact no policy can know
+
+```typescript
+// Don't hoist this above the spawns — teardown would hang waiting on `closed`.
+yield* ensure(function* () {
+  socket.close(1000, "released");
+  yield* closed;
+});
+```
+
+### Compliant: A deliberate deviation from a policy
+
+```typescript
+// We can't use `scoped` here to prevent losing the halt on effection
+// older than 4.1, where its own async teardown has that bug.
+finally: (fn) => from(/* ... spawn + ensure ... */),
+```
+
+Without this, the deviation reads as an oversight and the "fix" is a silent regression.
+
+## Verification Checklist
+
+Before marking a review complete, verify:
+
+- [ ] No comment restates what the adjacent code does
+- [ ] No comment repeats a rule that lives in `.policies/`
+- [ ] Comments guarding silent failures lead with the instruction
+- [ ] Version numbers appear only when tied to a constraint in the same package
+- [ ] Claims about what breaks have been verified, not reasoned
+- [ ] Every surviving comment survives question 4
+
+## Common Mistakes
+
+| Mistake                                  | Fix                                                    |
+| ---------------------------------------- | ------------------------------------------------------ |
+| Narrating the next line                  | Delete it                                              |
+| Repeating a policy at the call site      | Delete it; link the policy only when the code deviates |
+| Mechanism with no instruction            | Lead with what not to do                               |
+| "dropped in 4.0.3"                       | Say why it is absent, not when it happened             |
+| Overstating the blast radius             | State what actually happens                            |
+| Commenting to explain a confusing name   | Rename it                                              |
+
+## Related Policies
+
+- [Documentation Is Part of the API](./documentation.md) - Outward-facing docs; this policy governs inward comments
+- [Async Teardown](./async-teardown.md) - An example of a policy that comments must not repeat
+- [Naming and Consistency](./naming-consistency.md) - A better name usually removes the need for a comment
+- [Start With Why](./start-with-why.md) - Ask what a comment is for before rewriting it
+- [Policies Index](./index.md) - Add your new policy to the Policy Documents table

--- a/.policies/code-comments.md
+++ b/.policies/code-comments.md
@@ -1,6 +1,6 @@
-# Code Comments Policy (Recommended)
+# Code Comments Policy (Strict)
 
-This document defines the recommended policy for writing comments in source code.
+This document defines the strict policy for writing comments in source code.
 
 ## Core Principle
 

--- a/.policies/documentation.md
+++ b/.policies/documentation.md
@@ -106,4 +106,5 @@ Before marking a review complete, verify:
 
 - [Package.json Metadata](./package-json-metadata.md) - Package description requirements
 - [Backwards Compatibility](./backwards-compatibility.md) - Documenting breaking changes
+- [Code Comments](./code-comments.md) - Inward comments, which are held to the opposite standard
 - [Policies Index](./index.md) - Add your new policy to the Policy Documents table

--- a/.policies/index.md
+++ b/.policies/index.md
@@ -21,9 +21,9 @@ This is the **single source of truth** for all policies in this repository.
 | [Stateless Stream Operations](./stateless-streams.md)    | Recommended | Use `*[Symbol.iterator]` pattern for reusable stream operations        |
 | [Version Bump](./version-bump.md)                        | Recommended | PRs changing package code must include a semantic version bump         |
 | [Async Teardown](./async-teardown.md)                    | Recommended | Teardown that needs `yield*` must use `ensure()`, not a `finally` block |
-| [Code Comments](./code-comments.md)                      | Recommended | Comments say what the code cannot; delete the ones that restate it     |
 | [Package.json Metadata](./package-json-metadata.md)      | Strict      | Every published package must include a description field               |
 | [No Agent Marketing](./no-agent-marketing.md)            | Strict      | No AI tool promotional material in commits, PRs, issues, or comments   |
+| [Code Comments](./code-comments.md)                      | Strict      | Comments say what the code cannot; delete the ones that restate it     |
 
 ### Experimental Policies (cowboyd Review Patterns)
 

--- a/.policies/index.md
+++ b/.policies/index.md
@@ -21,6 +21,7 @@ This is the **single source of truth** for all policies in this repository.
 | [Stateless Stream Operations](./stateless-streams.md)    | Recommended | Use `*[Symbol.iterator]` pattern for reusable stream operations        |
 | [Version Bump](./version-bump.md)                        | Recommended | PRs changing package code must include a semantic version bump         |
 | [Async Teardown](./async-teardown.md)                    | Recommended | Teardown that needs `yield*` must use `ensure()`, not a `finally` block |
+| [Code Comments](./code-comments.md)                      | Recommended | Comments say what the code cannot; delete the ones that restate it     |
 | [Package.json Metadata](./package-json-metadata.md)      | Strict      | Every published package must include a description field               |
 | [No Agent Marketing](./no-agent-marketing.md)            | Strict      | No AI tool promotional material in commits, PRs, issues, or comments   |
 
@@ -61,6 +62,7 @@ API Design (balance)
 
 Code Quality
 ├── Type-Driven Design ◄── complements ──► Correctness Invariants
+├── Code Comments ◄──── tension ────► Documentation
 └── Naming Consistency ──► supports all policies
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,9 @@ When reviewing PRs:
 - Target ES2022
 - Prefer `type` imports for type-only imports
 - Use explicit return types on public functions
+- Comments must say what the code cannot. Do not narrate the next line, and do not
+  restate a rule that already lives in `.policies/`. Before keeping a comment, ask
+  why it is needed at all (see the [Code Comments policy](.policies/code-comments.md))
 
 ### Effection Patterns
 


### PR DESCRIPTION
Stacked on #225 — both add a row to `.policies/index.md`, so basing this on `main` would guarantee a conflict. GitHub will retarget to `main` automatically once #225 merges.

## Why

Every comment I wrote in #226 opened by narrating the code and only then got to the point. Reviewing them one at a time with @taras, the same thing happened five times: the prose describing what the comment *should* communicate was better than the comment itself.

That's a repeatable failure mode, not a one-off, and nothing in `.policies/` currently covers it — [`documentation.md`](https://github.com/thefrontside/effectionx/blob/main/.policies/documentation.md) governs outward-facing docs (JSDoc, examples, changelogs), which are held to the *opposite* standard.

## The rule

**A comment must say something the code cannot.** The test is four questions:

1. What is happening around the comment?
2. What does the comment say now?
3. What should it communicate?
4. **Why do we need this comment at all?**

The fourth removes most comments. If the honest answer is "so the reader understands the code", the code should be clearer instead.

## Writing rules

- Lead with the instruction, not the mechanism
- State the consequence, especially when the failure is silent
- Prefer *why* over *when* — version numbers rot unless tied to a live constraint in the same package
- Verify before you assert
- Don't overstate

## Examples

Real before/after pairs from #226 and #224, not invented ones. Including the three kinds of comment the review concluded were worth keeping:

- an **ordering constraint** (`Don't hoist this above the spawns — teardown would hang waiting on closed`)
- a **deliberate deviation** from another policy (`We can't use scoped here to prevent losing the halt on effection older than 4.1`)
- a **reach into a private API** (`intentionally omitted from Effection's public Coroutine because it's considered a private API`)

And the ones that were deleted: mechanism-without-instruction, when-instead-of-why, and restating `async-teardown.md` at the call site.

## State: Strict

Violations must be fixed before merge, alongside Package.json Metadata and No Agent Marketing.

## Also here

- `AGENTS.md` gains a line under Coding Standards. Agents write the comments this policy is about and read that section, not `.policies/`.
- `documentation.md` cross-references it, so the tension between the two is explicit rather than implied.

## Open question

Whether the "Commenting to explain a confusing name → Rename it" row belongs here or in `naming-consistency.md`.

Docs only, no version bumps.