### PR TITLE
🐛 Bound Windows process shutdown

### DIFF
--- a/process/CHANGELOG.md
+++ b/process/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @effection/process
 
+## \[0.8.2]
+
+- Bound graceful Windows process shutdown before force-killing the process tree.
+
 ## \[2.1.4]
 
 ### Dependencies

--- a/process/package.json
+++ b/process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/process",
   "description": "Spawn and manage child processes with structured concurrency",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/process/src/exec/win32.ts
+++ b/process/src/exec/win32.ts
@@ -13,6 +13,8 @@ import {
   all,
   createSignal,
   ensure,
+  race,
+  sleep,
   spawn,
   withResolvers,
 } from "effection";
@@ -28,6 +30,8 @@ import { ExecError } from "./error.ts";
 import { unbox, useEvalScope } from "@effectionx/scope-eval";
 
 type ProcessResultValue = [number?, string?];
+
+const gracefulShutdownTimeout = 1000;
 
 function* killTree(pid: number) {
   try {
@@ -177,16 +181,22 @@ export function* createWin32Process(
         stdin.end();
       }
 
-      // depending on how we shutdown, this may already be closed and
-      // will pass immediately over the operations
-      yield* all([io.stdoutDone.operation, io.stderrDone.operation]);
+      const closed = yield* race([
+        (function* () {
+          yield* processResult.operation;
+          return true;
+        })(),
+        (function* () {
+          yield* sleep(gracefulShutdownTimeout);
+          return false;
+        })(),
+      ]);
 
-      if (pid && childProcess.exitCode === null) {
-        // If the process is still around after we've waited
-        // for stdout and stderr to close,
-        // then force kill the tree.
+      if (pid && !closed) {
         yield* killTree(pid);
       }
+
+      yield* all([io.stdoutDone.operation, io.stderrDone.operation]);
     });
 
     return {

--- a/process/test/exec.test.ts
+++ b/process/test/exec.test.ts
@@ -162,6 +162,29 @@ describe("exec", () => {
         expect(status).toBeUndefined();
       });
     });
+
+    if (process.platform === "win32") {
+      it("force kills the process tree when graceful shutdown does not close stdio", function* () {
+        const ready = withResolvers<Process>();
+        const task = yield* spawn(function* () {
+          const proc = yield* exec("node", {
+            arguments: [
+              "--experimental-strip-types",
+              "fixtures/ignore-shutdown.ts",
+            ],
+            cwd: import.meta.dirname,
+          });
+          ready.resolve(proc);
+          yield* proc.join();
+        });
+
+        const proc = yield* ready.operation;
+        const started = yield* expectMatch(/ready/, lines()(proc.stdout));
+        expect(started).toBe(true);
+
+        expect(yield* task.halt()).toBeUndefined();
+      });
+    }
   });
 
   describe("successfully", () => {

--- a/process/test/fixtures/ignore-shutdown.ts
+++ b/process/test/fixtures/ignore-shutdown.ts
@@ -1,0 +1,24 @@
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const descendant = spawn(
+  process.execPath,
+  ["-e", 'process.on("SIGINT", () => {}); setInterval(() => {}, 1000);'],
+  {
+    stdio: ["ignore", "inherit", "inherit"],
+    windowsHide: true,
+  },
+);
+
+descendant.once("spawn", () => {
+  console.log("ready");
+});
+
+descendant.once("error", (error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+
+process.on("SIGINT", () => {});
+process.stdin.resume();
+setInterval(() => {}, 1000);


### PR DESCRIPTION
# Motivation

Windows teardown currently waits for stdout and stderr EOF before checking whether it should run `taskkill /T /F`. When a process or descendant keeps an inherited output handle open, that wait never completes, the force-kill fallback is unreachable, and scope teardown hangs.

This is the Windows-specific follow-up to #228 and is intentionally separate from the `Process.exited()` API work in #230.

# Approach

- Send Ctrl-C and close stdin as the graceful shutdown phase.
- Race close-settled process completion against a one-second grace period.
- Run `taskkill /T /F` when the grace period expires, then await final stdout and stderr closure.
- Add a Windows-only lifecycle regression whose parent and inherited-stdio descendant ignore Ctrl-C, requiring the process-tree fallback for `Task.halt()` to finish.
- Bump `@effectionx/process` from 0.8.1 to 0.8.2.

# Validation

- `pnpm check`
- `pnpm build`
- `pnpm lint`
- `pnpm fmt:check`
- `pnpm sync`
- `pnpm test:node` (34 passed)
- `pnpm test process` (36 passed locally; Windows-only regression skipped on macOS)
- `pnpm test` (382 passed, 6 skipped)
