### PR TITLE
🐛 Avoid aborting settled fetches

### DIFF
--- a/fetch/README.md
+++ b/fetch/README.md
@@ -132,8 +132,9 @@ Returns a `FetchOperation` that supports both fluent chaining and traditional us
 - `init` - Optional `FetchInit` options (same as `RequestInit` but without `signal`)
 
 Cancellation is handled automatically via Effection's structured concurrency. When the
-scope exits, the request is aborted. The `signal` option is intentionally omitted since
-Effection manages cancellation for you.
+scope exits, an in-flight request is aborted. A native fetch that has already settled is
+left intact. The `signal` option is intentionally omitted since Effection manages
+cancellation for you.
 
 ### `FetchOperation`
 

--- a/fetch/api.ts
+++ b/fetch/api.ts
@@ -30,16 +30,11 @@ export const FetchApi: Api<Fetch> = createApi("fetch", {
     });
 
     let response = yield* until(
-      globalThis.fetch(input, { ...init, signal: controller.signal }).then(
-        (value) => {
+      globalThis
+        .fetch(input, { ...init, signal: controller.signal })
+        .finally(() => {
           settled = true;
-          return value;
-        },
-        (error) => {
-          settled = true;
-          throw error;
-        },
-      ),
+        }),
     );
     let fetchResponse = createFetchResponse(response);
 

--- a/fetch/api.ts
+++ b/fetch/api.ts
@@ -1,5 +1,5 @@
 import { type Api, createApi } from "@effectionx/context-api";
-import { type Operation, until, useAbortSignal } from "effection";
+import { type Operation, ensure, until } from "effection";
 
 import { createFetchResponse } from "./create-fetch-response.ts";
 import { type FetchInit, type FetchResponse, HttpError } from "./fetch.ts";
@@ -18,8 +18,29 @@ export const FetchApi: Api<Fetch> = createApi("fetch", {
     init: FetchInit | undefined,
     shouldExpect: boolean,
   ): Operation<FetchResponse> {
-    let signal = yield* useAbortSignal();
-    let response = yield* until(globalThis.fetch(input, { ...init, signal }));
+    // Do not replace this with useAbortSignal(); its unconditional scope-exit
+    // abort can make Node's fetch throw after the request has settled.
+    let controller = new AbortController();
+    let settled = false;
+
+    yield* ensure(() => {
+      if (!settled) {
+        controller.abort();
+      }
+    });
+
+    let response = yield* until(
+      globalThis.fetch(input, { ...init, signal: controller.signal }).then(
+        (value) => {
+          settled = true;
+          return value;
+        },
+        (error) => {
+          settled = true;
+          throw error;
+        },
+      ),
+    );
     let fetchResponse = createFetchResponse(response);
 
     if (shouldExpect && !response.ok) {

--- a/fetch/fetch.test.ts
+++ b/fetch/fetch.test.ts
@@ -200,6 +200,64 @@ describe("fetch()", () => {
     });
   });
 
+  describe("cancellation", () => {
+    it("does not abort a settled native fetch when its scope closes", function* () {
+      let nativeFetch = globalThis.fetch;
+      let requestSignal: AbortSignal | null | undefined;
+
+      globalThis.fetch = (input, init) => {
+        requestSignal = init?.signal;
+        return nativeFetch(input, init);
+      };
+
+      try {
+        let task = yield* spawn(function* () {
+          yield* fetch("data:text/plain,hello");
+        });
+
+        yield* task;
+
+        expect(requestSignal).toBeDefined();
+        expect(requestSignal?.aborted).toBe(false);
+      } finally {
+        globalThis.fetch = nativeFetch;
+      }
+    });
+
+    it("aborts an in-flight native fetch when its scope closes", function* () {
+      let nativeFetch = globalThis.fetch;
+      let started = withResolvers<AbortSignal>();
+
+      globalThis.fetch = (_input, init) =>
+        new Promise((_resolve, reject) => {
+          let signal = init?.signal;
+
+          if (!signal) {
+            reject(new Error("expected fetch to receive an abort signal"));
+            return;
+          }
+
+          started.resolve(signal);
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        });
+
+      try {
+        let task = yield* spawn(function* () {
+          yield* fetch("https://example.test/pending");
+        });
+        let requestSignal = yield* started.operation;
+
+        yield* task.halt();
+
+        expect(requestSignal.aborted).toBe(true);
+      } finally {
+        globalThis.fetch = nativeFetch;
+      }
+    });
+  });
+
   describe("middleware API", () => {
     it("can intercept requests with logging", function* () {
       let requestedUrls: string[] = [];

--- a/fetch/fetch.ts
+++ b/fetch/fetch.ts
@@ -125,7 +125,7 @@ export class HttpError extends Error {
  * Perform an HTTP request using the Fetch API with Effection structured concurrency.
  *
  * Cancellation is automatically handled via the current Effection scope.
- * When the scope exits, the request is aborted.
+ * When the scope exits, an in-flight request is aborted.
  *
  * @param input - The URL or Request object
  * @param init - Optional request configuration (same as RequestInit, but without signal)

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/fetch",
   "description": "Effection-native fetch with structured concurrency and streaming response support",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "keywords": ["io", "streams"],
   "type": "module",
   "main": "./dist/mod.js",


### PR DESCRIPTION
## Motivation

Node's native fetch can raise a late Undici exception when Effection tears down a scope and aborts a request whose fetch promise has already settled. This is reproducible with a `data:` URL and can surface after the owning operation has completed.

Closes #232.

## Approach

- Track settlement of the native fetch promise.
- Abort through a local controller only while that promise is still pending.
- Preserve cancellation when an in-flight fetch operation is halted.
- Document the settlement-aware lifecycle and bump `@effectionx/fetch` to `0.2.1`.
- Add a real Node `data:` regression test plus deterministic in-flight cancellation coverage.

The lifecycle boundary is the native fetch promise's settlement: once it produces a `Response` (or rejects), later scope teardown does not abort it.

## Verification

- `pnpm test` — 384 passed, 6 skipped
- `pnpm check`
- `pnpm lint`
- `pnpm fmt:check`
- `pnpm build`
- `pnpm sync`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed fetch requests now remain intact when their Effection scope exits.
  * In-flight fetch requests are automatically aborted when their scope is cancelled or exits.

* **Documentation**
  * Clarified fetch cancellation behavior and lifecycle expectations.

* **Chores**
  * Updated the fetch package version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->