### PR TITLE
🐛 Arm process kill-teardown before spawning the child

### DIFF
--- a/process/src/exec/posix.ts
+++ b/process/src/exec/posix.ts
@@ -1,4 +1,4 @@
-import { spawn as spawnProcess } from "node:child_process";
+import { type ChildProcess, spawn as spawnProcess } from "node:child_process";
 import process from "node:process";
 import {
   type Result,
@@ -14,7 +14,6 @@ import {
   withResolvers,
 } from "effection";
 import { unbox, useEvalScope } from "@effectionx/scope-eval";
-import { once } from "@effectionx/node/events";
 import { fromReadable } from "@effectionx/node/stream";
 import type {
   CreateOSProcess,
@@ -38,6 +37,92 @@ export function* createPosixProcess(
   let processResult = withResolvers<Result<ProcessResultValue>>();
   const evalScope = yield* useEvalScope();
   const result = yield* evalScope.eval(function* () {
+    let stdoutDone = withResolvers<void>();
+    let stderrDone = withResolvers<void>();
+
+    let childProcess: ChildProcess | undefined;
+    let teardownStarted = false;
+
+    const shutdown = options.shutdown ?? "graceful";
+
+    const exit: Operation<ExitStatus> = {
+      *[Symbol.iterator]() {
+        let result = yield* exitResult.operation;
+        if (result.ok) {
+          let [code, signal] = result.value;
+          return { command, options, code, signal } as ExitStatus;
+        }
+        throw result.error;
+      },
+    };
+
+    function* terminate(): Operation<void> {
+      let pid = childProcess?.pid;
+      if (typeof pid !== "undefined") {
+        try {
+          process.kill(-pid, "SIGKILL");
+        } catch (_error) {}
+      }
+    }
+
+    function* reaped(): Operation<void> {
+      yield* processResult.operation;
+    }
+
+    function* closed(): Operation<void> {
+      yield* all([
+        processResult.operation,
+        stdoutDone.operation,
+        stderrDone.operation,
+      ]);
+    }
+
+    function* shutdownProcess(join: () => Operation<void>): Operation<void> {
+      let pid = childProcess?.pid;
+      if (typeof pid === "undefined") {
+        return;
+      }
+
+      function* gracefulCompletion(): Operation<ShutdownMode> {
+        yield* join();
+        return "graceful";
+      }
+
+      if (shutdown === "forced") {
+        yield* terminate();
+      } else {
+        try {
+          process.kill(-pid, "SIGTERM");
+        } catch (_error) {}
+
+        if (typeof shutdown === "function") {
+          let mode: ShutdownMode;
+          try {
+            mode = yield* race([gracefulCompletion(), shutdown({ exit })]);
+          } catch (_error) {
+            mode = "forced";
+          }
+          if (mode === "forced") {
+            yield* terminate();
+          }
+        }
+      }
+
+      yield* settled(join());
+    }
+
+    // A halt can land on any suspension point between here and the primary
+    // teardown at the end of this generator, discarding every instruction
+    // after it. This guard registers while `childProcess` is still empty and
+    // the spawn below follows in the same synchronous continuation, so at no
+    // point does the process exist without an armed teardown. It joins on
+    // process exit alone because the stdio pumps may never have been wired.
+    yield* ensure(function* () {
+      if (!teardownStarted) {
+        yield* shutdownProcess(reaped);
+      }
+    });
+
     // Killing all child processes started by this command is surprisingly
     // tricky. If a process spawns another processes and we kill the parent,
     // then the child process is NOT automatically killed. Instead we're using
@@ -48,25 +133,38 @@ export function* createPosixProcess(
     // process.
     //
     // More information here: https://unix.stackexchange.com/questions/14815/process-descendants
-    let childProcess = spawnProcess(command, options.arguments || [], {
+    const child = spawnProcess(command, options.arguments || [], {
       detached: true,
       shell: options.shell,
       env: options.env,
       cwd: options.cwd,
       stdio: "pipe",
     });
+    childProcess = child;
 
-    let { pid } = childProcess;
+    // Node listeners instead of spawned effection watchers: exit observation
+    // must arm in the same synchronous continuation as the spawn so that the
+    // guard above can join on it no matter where a halt lands.
+    child.once("error", (error) => {
+      exitResult.resolve(Err(error));
+      processResult.resolve(Err(error));
+    });
+    child.once("exit", (code, signal) => {
+      exitResult.resolve(Ok([code ?? undefined, signal ?? undefined]));
+    });
+    child.once("close", (code, signal) => {
+      processResult.resolve(Ok([code ?? undefined, signal ?? undefined]));
+    });
 
-    if (!childProcess.stdout || !childProcess.stderr) {
+    let { pid } = child;
+
+    if (!child.stdout || !child.stderr) {
       throw new Error("stdout and stderr must be available with stdio: pipe");
     }
 
     let io = {
-      stdout: yield* fromReadable(childProcess.stdout),
-      stderr: yield* fromReadable(childProcess.stderr),
-      stdoutDone: withResolvers<void>(),
-      stderrDone: withResolvers<void>(),
+      stdout: yield* fromReadable(child.stdout),
+      stderr: yield* fromReadable(child.stderr),
     };
 
     let stdout = createSignal<Uint8Array, void>();
@@ -80,7 +178,7 @@ export function* createPosixProcess(
         next = yield* io.stdout.next();
       }
       stdout.close();
-      io.stdoutDone.resolve();
+      stdoutDone.resolve();
     });
 
     yield* spawn(function* () {
@@ -91,39 +189,12 @@ export function* createPosixProcess(
         next = yield* io.stderr.next();
       }
       stderr.close();
-      io.stderrDone.resolve();
+      stderrDone.resolve();
     });
 
     let stdin: Writable<string> = {
       send(data: string) {
-        childProcess.stdin.write(data);
-      },
-    };
-
-    yield* spawn(function* trapError() {
-      let [error] = yield* once<[Error]>(childProcess, "error");
-      exitResult.resolve(Err(error));
-      processResult.resolve(Err(error));
-    });
-
-    yield* spawn(function* () {
-      let value = yield* once<ProcessResultValue>(childProcess, "exit");
-      exitResult.resolve(Ok(value));
-    });
-
-    yield* spawn(function* () {
-      let value = yield* once<ProcessResultValue>(childProcess, "close");
-      processResult.resolve(Ok(value));
-    });
-
-    const exit: Operation<ExitStatus> = {
-      *[Symbol.iterator]() {
-        let result = yield* exitResult.operation;
-        if (result.ok) {
-          let [code, signal] = result.value;
-          return { command, options, code, signal } as ExitStatus;
-        }
-        throw result.error;
+        child.stdin.write(data);
       },
     };
 
@@ -144,54 +215,9 @@ export function* createPosixProcess(
       return status;
     }
 
-    function* closed(): Operation<void> {
-      yield* all([
-        processResult.operation,
-        io.stdoutDone.operation,
-        io.stderrDone.operation,
-      ]);
-    }
-
-    function* gracefulCompletion(): Operation<ShutdownMode> {
-      yield* closed();
-      return "graceful";
-    }
-
-    function* terminate(): Operation<void> {
-      if (typeof pid !== "undefined") {
-        try {
-          process.kill(-pid, "SIGKILL");
-        } catch (_error) {}
-      }
-    }
-
-    const shutdown = options.shutdown ?? "graceful";
-
     yield* ensure(function* () {
-      if (shutdown === "forced") {
-        yield* terminate();
-      } else {
-        try {
-          if (typeof pid === "undefined") {
-            throw new Error("no pid for childProcess");
-          }
-          process.kill(-pid, "SIGTERM");
-        } catch (_error) {}
-
-        if (typeof shutdown === "function") {
-          let mode: ShutdownMode;
-          try {
-            mode = yield* race([gracefulCompletion(), shutdown({ exit })]);
-          } catch (_error) {
-            mode = "forced";
-          }
-          if (mode === "forced") {
-            yield* terminate();
-          }
-        }
-      }
-
-      yield* settled(closed());
+      teardownStarted = true;
+      yield* shutdownProcess(closed);
     });
 
     return {

--- a/process/src/exec/win32.ts
+++ b/process/src/exec/win32.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from "node:child_process";
 import { platform } from "node:os";
 import { once } from "@effectionx/node/events";
 import { fromReadable } from "@effectionx/node/stream";
@@ -53,90 +54,24 @@ export function* createWin32Process(
   let processResult = withResolvers<Result<ProcessResultValue>>();
   const evalScope = yield* useEvalScope();
   const result = yield* evalScope.eval(function* () {
-    // Windows-specific process spawning with different options than POSIX
-    let childProcess = spawnProcess(command, options.arguments || [], {
-      // We lose exit information and events if this is detached in windows
-      // and it opens a window in windows+powershell.
-      detached: false,
-      // The `shell` option is passed to `cross-spawn` to control whether a shell is used.
-      // On Windows, `shell: true` is necessary to run command strings, as it uses
-      // `cmd.exe` to parse the command and find executables in the PATH.
-      // Using a boolean `true` was previously disabled, causing ENOENT errors for
-      // commands that were not a direct path to an executable.
-      shell: options.shell || false,
-      // With stdio as pipe, windows gets stuck where neither the child nor the
-      // parent wants to close the stream, so we call it ourselves in the exit event.
-      stdio: "pipe",
-      // Hide the child window so that killing it will not block the parent
-      // with a Terminate Batch Process (Y/n)
-      windowsHide: true,
-      env: options.env,
-      cwd: options.cwd,
-    });
+    let stdoutDone = withResolvers<void>();
+    let stderrDone = withResolvers<void>();
+    let rawClose = withResolvers<Result<ProcessResultValue>>();
 
-    let { pid } = childProcess;
+    let childProcess: ChildProcess | undefined;
+    let teardownStarted = false;
 
-    if (!childProcess.stdout || !childProcess.stderr) {
-      throw new Error("stdout and stderr must be available with stdio: pipe");
+    const shutdown = options.shutdown ?? "graceful";
+
+    let hardTerminationRequested = false;
+    const hardTerminationRequest = withResolvers<void>();
+
+    function requestHardTermination(): void {
+      if (!hardTerminationRequested) {
+        hardTerminationRequested = true;
+        hardTerminationRequest.resolve();
+      }
     }
-
-    let io = {
-      stdout: yield* fromReadable(childProcess.stdout),
-      stderr: yield* fromReadable(childProcess.stderr),
-      stdoutDone: withResolvers<void>(),
-      stderrDone: withResolvers<void>(),
-    };
-
-    const stdout = createSignal<Uint8Array, void>();
-    const stderr = createSignal<Uint8Array, void>();
-
-    yield* spawn(function* () {
-      let next = yield* io.stdout.next();
-      while (!next.done) {
-        yield* Stdio.operations.stdout(next.value);
-        stdout.send(next.value);
-        next = yield* io.stdout.next();
-      }
-      stdout.close();
-      io.stdoutDone.resolve();
-    });
-
-    yield* spawn(function* () {
-      let next = yield* io.stderr.next();
-      while (!next.done) {
-        yield* Stdio.operations.stderr(next.value);
-        stderr.send(next.value);
-        next = yield* io.stderr.next();
-      }
-      stderr.close();
-      io.stderrDone.resolve();
-    });
-
-    let stdin: Writable<string> = {
-      send(data: string) {
-        childProcess.stdin.write(data);
-      },
-    };
-
-    yield* spawn(function* trapError() {
-      const [error] = yield* once<Error[]>(childProcess, "error");
-      exitResult.resolve(Err(error));
-      processResult.resolve(Err(error));
-    });
-
-    yield* spawn(function* () {
-      let value = yield* once<ProcessResultValue>(childProcess, "exit");
-      exitResult.resolve(Ok(value));
-    });
-
-    yield* spawn(function* () {
-      let value = yield* once<ProcessResultValue>(childProcess, "close");
-      // out of band with the finally block below compared to posix as
-      // win32 is more sensitive to graceful shutdown timing that it is
-      // worth waiting for stdout and stderr to close before resolving the process result
-      yield* all([io.stdoutDone.operation, io.stderrDone.operation]);
-      processResult.resolve(Ok(value));
-    });
 
     const exit: Operation<ExitStatus> = {
       *[Symbol.iterator]() {
@@ -149,77 +84,47 @@ export function* createWin32Process(
       },
     };
 
-    function* join() {
-      let result = yield* processResult.operation;
-      if (result.ok) {
-        let [code, signal] = result.value;
-        return { command, options, code, signal } as ExitStatus;
-      }
-      throw result.error;
-    }
-
-    function* expect() {
-      let status = yield* join();
-      if (status.code !== 0) {
-        throw new ExecError(status, command, options);
-      }
-      return status;
+    function* reaped(): Operation<void> {
+      yield* rawClose.operation;
     }
 
     function* closed(): Operation<void> {
       yield* all([
         processResult.operation,
-        io.stdoutDone.operation,
-        io.stderrDone.operation,
+        stdoutDone.operation,
+        stderrDone.operation,
       ]);
     }
 
-    function* gracefulCompletion(): Operation<ShutdownMode> {
-      yield* closed();
-      return "graceful";
-    }
-
-    let hardTerminationRequested = false;
-    const hardTerminationRequest = withResolvers<void>();
-
-    function requestHardTermination(): void {
-      if (!hardTerminationRequested) {
-        hardTerminationRequested = true;
-        hardTerminationRequest.resolve();
+    function* shutdownProcess(join: () => Operation<void>): Operation<void> {
+      let child = childProcess;
+      let pid = child?.pid;
+      if (!child || typeof pid === "undefined") {
+        return;
       }
-    }
 
-    const shutdown = options.shutdown ?? "graceful";
-
-    // Suppress EPIPE errors on stdin - these occur on Windows when the child
-    // process exits before we finish writing to it. This is expected during
-    // cleanup when we're killing the process.
-    childProcess.stdin.on("error", (err: Error & { code?: string }) => {
-      if (err.code !== "EPIPE") {
-        throw err;
+      function* gracefulCompletion(): Operation<ShutdownMode> {
+        yield* join();
+        return "graceful";
       }
-    });
 
-    yield* ensure(function* () {
       const hardTerminationTask =
         shutdown !== "graceful"
           ? yield* spawn(function* () {
               yield* hardTerminationRequest.operation;
-              if (pid) {
-                yield* killTree(pid);
-              }
+              yield* killTree(pid);
             })
           : undefined;
 
       if (shutdown === "forced") {
         requestHardTermination();
       } else {
-        if (pid) {
-          try {
-            ctrlc(pid);
-          } catch (_) {}
+        try {
+          ctrlc(pid);
+        } catch (_) {}
 
-          let stdin = childProcess.stdin;
+        let stdin = child.stdin;
+        if (stdin) {
           if (stdin.writable) {
             try {
               stdin.write("Y\n");
@@ -249,7 +154,140 @@ export function* createWin32Process(
         }
       }
 
-      yield* settled(closed());
+      yield* settled(join());
+    }
+
+    // A halt can land on any suspension point between here and the primary
+    // teardown at the end of this generator, discarding every instruction
+    // after it. This guard registers while `childProcess` is still empty and
+    // the spawn below follows in the same synchronous continuation, so at no
+    // point does the process exist without an armed teardown. It joins on
+    // process exit alone because the stdio pumps may never have been wired.
+    yield* ensure(function* () {
+      if (!teardownStarted) {
+        yield* shutdownProcess(reaped);
+      }
+    });
+
+    // Windows-specific process spawning with different options than POSIX
+    const child = spawnProcess(command, options.arguments || [], {
+      // We lose exit information and events if this is detached in windows
+      // and it opens a window in windows+powershell.
+      detached: false,
+      // The `shell` option is passed to `cross-spawn` to control whether a shell is used.
+      // On Windows, `shell: true` is necessary to run command strings, as it uses
+      // `cmd.exe` to parse the command and find executables in the PATH.
+      // Using a boolean `true` was previously disabled, causing ENOENT errors for
+      // commands that were not a direct path to an executable.
+      shell: options.shell || false,
+      // With stdio as pipe, windows gets stuck where neither the child nor the
+      // parent wants to close the stream, so we call it ourselves in the exit event.
+      stdio: "pipe",
+      // Hide the child window so that killing it will not block the parent
+      // with a Terminate Batch Process (Y/n)
+      windowsHide: true,
+      env: options.env,
+      cwd: options.cwd,
+    });
+    childProcess = child;
+
+    // Node listeners instead of spawned effection watchers: exit observation
+    // must arm in the same synchronous continuation as the spawn so that the
+    // guard above can join on it no matter where a halt lands.
+    child.once("error", (error) => {
+      exitResult.resolve(Err(error));
+      processResult.resolve(Err(error));
+      rawClose.resolve(Err(error));
+    });
+    child.once("exit", (code, signal) => {
+      exitResult.resolve(Ok([code ?? undefined, signal ?? undefined]));
+    });
+    child.once("close", (code, signal) => {
+      rawClose.resolve(Ok([code ?? undefined, signal ?? undefined]));
+    });
+
+    // Suppress EPIPE errors on stdin - these occur on Windows when the child
+    // process exits before we finish writing to it. This is expected during
+    // cleanup when we're killing the process.
+    child.stdin.on("error", (err: Error & { code?: string }) => {
+      if (err.code !== "EPIPE") {
+        throw err;
+      }
+    });
+
+    let { pid } = child;
+
+    if (!child.stdout || !child.stderr) {
+      throw new Error("stdout and stderr must be available with stdio: pipe");
+    }
+
+    let io = {
+      stdout: yield* fromReadable(child.stdout),
+      stderr: yield* fromReadable(child.stderr),
+    };
+
+    const stdout = createSignal<Uint8Array, void>();
+    const stderr = createSignal<Uint8Array, void>();
+
+    yield* spawn(function* () {
+      let next = yield* io.stdout.next();
+      while (!next.done) {
+        yield* Stdio.operations.stdout(next.value);
+        stdout.send(next.value);
+        next = yield* io.stdout.next();
+      }
+      stdout.close();
+      stdoutDone.resolve();
+    });
+
+    yield* spawn(function* () {
+      let next = yield* io.stderr.next();
+      while (!next.done) {
+        yield* Stdio.operations.stderr(next.value);
+        stderr.send(next.value);
+        next = yield* io.stderr.next();
+      }
+      stderr.close();
+      stderrDone.resolve();
+    });
+
+    let stdin: Writable<string> = {
+      send(data: string) {
+        child.stdin.write(data);
+      },
+    };
+
+    yield* spawn(function* () {
+      let result = yield* rawClose.operation;
+      if (result.ok) {
+        // win32 is more sensitive to graceful shutdown timing than posix, so
+        // it is worth waiting for stdout and stderr to close before resolving
+        // the process result
+        yield* all([stdoutDone.operation, stderrDone.operation]);
+      }
+      processResult.resolve(result);
+    });
+
+    function* join() {
+      let result = yield* processResult.operation;
+      if (result.ok) {
+        let [code, signal] = result.value;
+        return { command, options, code, signal } as ExitStatus;
+      }
+      throw result.error;
+    }
+
+    function* expect() {
+      let status = yield* join();
+      if (status.code !== 0) {
+        throw new ExecError(status, command, options);
+      }
+      return status;
+    }
+
+    yield* ensure(function* () {
+      teardownStarted = true;
+      yield* shutdownProcess(closed);
     });
 
     return {

--- a/process/test/exec.test.ts
+++ b/process/test/exec.test.ts
@@ -1,11 +1,14 @@
+import { execSync } from "node:child_process";
 import process from "node:process";
 import { beforeEach, describe, it } from "@effectionx/vitest";
 import {
+  type Operation,
   type Task,
   createContext,
   sleep,
   spawn,
   suspend,
+  useScope,
   withResolvers,
 } from "effection";
 import { expect } from "expect";
@@ -774,4 +777,65 @@ describe("exec", () => {
       });
     }
   });
+
+  if (process.platform !== "win32") {
+    describe("halt during acquisition", () => {
+      function deep(
+        levels: number,
+        body: () => Operation<void>,
+      ): Operation<void> {
+        if (levels === 0) {
+          return body();
+        }
+        return {
+          *[Symbol.iterator]() {
+            const inner = yield* spawn(() => deep(levels - 1, body));
+            yield* inner;
+          },
+        };
+      }
+
+      function isRunning(marker: string): boolean {
+        const commands = execSync("ps -axww -o command").toString();
+        return commands
+          .split("\n")
+          .some((line) => line.includes(marker) && !line.includes("ps -axww"));
+      }
+
+      it("never leaves the child process behind, wherever the halt lands", function* () {
+        // The scheduler interleaves same-generation routines one
+        // instruction per turn, so a halter spawned one scope deeper than
+        // the exec task runs in lockstep with the acquisition sequence.
+        // Sweeping the number of turns before the halt lands it on every
+        // suspension point of that sequence — including between the OS
+        // spawn and the registration of the kill-teardown (#236).
+        for (let turns = 0; turns < 40; turns++) {
+          const marker = `halt-sweep-236-${process.pid}-${turns}`;
+          const task = yield* spawn(function* () {
+            yield* exec("node", {
+              arguments: ["-e", "setTimeout(() => {}, 30000)", marker],
+            });
+            yield* suspend();
+          });
+          const halter = yield* spawn(() =>
+            deep(1, function* () {
+              for (let t = 0; t < turns; t++) {
+                yield* useScope();
+              }
+              yield* task.halt();
+            }),
+          );
+          yield* halter;
+          if (isRunning(marker)) {
+            try {
+              execSync(`pkill -f ${marker}`);
+            } catch (_error) {}
+            throw new Error(
+              `process orphaned when halted after ${turns} scheduler turns`,
+            );
+          }
+        }
+      }, 30000);
+    });
+  }
 });


### PR DESCRIPTION
Fixes #236

## Problem

A scope halted while `exec` is acquiring its child process can leave the child — and its whole process tree — running with no owner. The OS process was created first and the `ensure` that terminates it registered last, with several suspension points in between. A halt landing on any of them discards the remaining instructions, so the kill-teardown never arms and the orphan runs to completion. The window cannot be guarded from the caller's side: it is inside the single `yield* exec(...)`, so the caller never receives a `Process` to clean up with.

## Fix

Both `createPosixProcess` and `createWin32Process` now:

- register a **guard teardown before the process exists**, and create the process in the same synchronous continuation — a halt lands either before the spawn (nothing to clean up) or after the teardown is armed, never between;
- resolve exit/close/error through **Node listeners attached in the spawn's continuation** instead of spawned effection watchers, so the guard can always join on process exit no matter where a halt lands;
- keep the primary teardown at the end of acquisition unchanged in position and semantics (it still runs first at teardown, while the stdio pumps are alive, preserving the drain-before-halt ordering from #228). The guard stands down once the primary teardown has begun, and joins on process exit alone since the pumps may never have been wired.

The shutdown-mode logic (`graceful` / `forced` / policy function) is factored into a single `shutdownProcess(join)` used by both teardowns, so the orphan-window path honors the configured shutdown semantics too.

## Regression test

Effection's reducer interleaves same-generation routines one instruction per turn. The new test spawns a halter one scope generation deeper than the exec task — the same generation as the acquisition's internal routines — and sweeps the number of turns before `task.halt()`, deterministically landing the halt on every suspension point of the acquisition sequence, then asserts via `ps` that no child survives. Against the previous code this reliably orphans the child (halts landing after the spawn but before the teardown registration); with the fix, all sweep positions stay clean. No timers, no load dependence.

Stacked on #230 (`agent/process-exited`).