### PR TITLE
🐛 Propagate premature daemon exits

### DIFF
--- a/process/api.ts
+++ b/process/api.ts
@@ -1,8 +1,7 @@
 import { type Api, createApi } from "@effectionx/context-api";
 import type { Operation } from "effection";
-import { resource } from "effection";
+import { resource, spawn } from "effection";
 
-import type { Daemon } from "./src/daemon.ts";
 import type { ExecOptions, Process } from "./src/exec/types.ts";
 import { DaemonExitError } from "./src/exec/error.ts";
 import { createPosixProcess } from "./src/exec/posix.ts";
@@ -10,7 +9,7 @@ import { createWin32Process, isWin32 } from "./src/exec/win32.ts";
 
 export interface ProcessHandler {
   exec(command: string, options: ExecOptions): Operation<Process>;
-  daemon(command: string, options: ExecOptions): Operation<Daemon>;
+  daemon(command: string, options: ExecOptions): Operation<Process>;
 }
 
 export const ProcessApi: Api<ProcessHandler> = createApi(
@@ -23,17 +22,16 @@ export const ProcessApi: Api<ProcessHandler> = createApi(
       return yield* createPosixProcess(command, options);
     },
 
-    *daemon(command: string, options: ExecOptions): Operation<Daemon> {
+    *daemon(command: string, options: ExecOptions): Operation<Process> {
       return yield* resource(function* (provide) {
         let process = yield* ProcessApi.operations.exec(command, options);
 
-        yield* provide({
-          *[Symbol.iterator]() {
-            let status = yield* process.join();
-            throw new DaemonExitError(status, command, options);
-          },
-          ...process,
+        yield* spawn(function* supervise() {
+          let status = yield* process.join();
+          throw new DaemonExitError(status, command, options);
         });
+
+        yield* provide(process);
       });
     },
   },

--- a/process/mod.ts
+++ b/process/mod.ts
@@ -1,4 +1,4 @@
 export * from "./api.ts";
 export * from "./src/exec.ts";
-export { type Daemon, daemon } from "./src/daemon.ts";
+export { daemon } from "./src/daemon.ts";
 export * from "./src/api.ts";

--- a/process/package.json
+++ b/process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/process",
   "description": "Spawn and manage child processes with structured concurrency",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/process/src/daemon.ts
+++ b/process/src/daemon.ts
@@ -3,8 +3,6 @@ import type { Operation } from "effection";
 import { ProcessApi } from "../api.ts";
 import type { ExecOptions, Process } from "./exec.ts";
 
-export interface Daemon extends Operation<void>, Process {}
-
 /**
  * Start a long-running process, like a web server that run perpetually.
  * Daemon operations are expected to run forever, and if they exit pre-maturely
@@ -13,6 +11,6 @@ export interface Daemon extends Operation<void>, Process {}
 export function daemon(
   command: string,
   options: ExecOptions = {},
-): Operation<Daemon> {
+): Operation<Process> {
   return ProcessApi.operations.daemon(command, options);
 }

--- a/process/test/daemon.test.ts
+++ b/process/test/daemon.test.ts
@@ -1,20 +1,41 @@
 import process from "node:process";
+import { platform } from "node:os";
 import { beforeEach, describe, it } from "@effectionx/vitest";
-import { type Task, sleep, spawn, until, withResolvers } from "effection";
+import {
+  type Operation,
+  type Task,
+  scoped,
+  sleep,
+  spawn,
+  suspend,
+  until,
+  withResolvers,
+} from "effection";
 import { expect } from "expect";
 
 import { lines } from "@effectionx/stream-helpers";
-import { type Daemon, daemon } from "../mod.ts";
+import { daemon, DaemonExitError, type Process, ProcessApi } from "../mod.ts";
 import { captureError, expectMatch, fetchText } from "./helpers.ts";
 
 const SystemRoot = process.env.SystemRoot;
 
+function* waitForProcessExit(pid: number): Operation<void> {
+  while (true) {
+    try {
+      process.kill(pid, 0);
+      yield* sleep(0);
+    } catch {
+      return;
+    }
+  }
+}
+
 describe("daemon", () => {
   describe("controlling from outside", () => {
     let task: Task<void>;
-    let proc: Daemon;
+    let proc: Process;
     beforeEach(function* () {
-      const result = withResolvers<Daemon>();
+      const result = withResolvers<Process>();
       task = yield* spawn<void>(function* () {
         proc = yield* daemon("node", {
           arguments: [
@@ -29,7 +50,7 @@ describe("daemon", () => {
           cwd: import.meta.dirname,
         });
         result.resolve(proc);
-        yield* proc;
+        yield* suspend();
       });
 
       proc = yield* result.operation;
@@ -67,47 +88,52 @@ describe("daemon", () => {
     });
   });
 
-  describe("shutting down the daemon process prematurely", () => {
-    let task: Task<Error>;
-    beforeEach(function* () {
-      let proc = yield* daemon("node", {
-        arguments: ["--experimental-strip-types", "fixtures/echo-server.ts"],
-        env: {
-          PORT: "29001",
-          PATH: process.env.PATH as string,
-          ...(SystemRoot ? { SystemRoot } : {}),
-        },
-        cwd: import.meta.dirname,
+  describe.skipIf(platform() === "win32")(
+    "shutting down the daemon process prematurely",
+    () => {
+      let sibling: Process;
+      let error: DaemonExitError;
+
+      beforeEach(function* () {
+        const commands: string[] = [];
+
+        yield* ProcessApi.around({
+          *exec(args, next) {
+            commands.push(args[0]);
+            return yield* next(...args);
+          },
+        });
+
+        error = (yield* captureError(
+          scoped(function* () {
+            const failing = yield* daemon("node", {
+              arguments: ["-e", "setInterval(() => {}, 1000)"],
+            });
+            sibling = yield* daemon("node", {
+              arguments: ["-e", "setInterval(() => {}, 1000)"],
+            });
+
+            process.kill(failing.pid, "SIGTERM");
+            yield* suspend();
+          }),
+        )) as DaemonExitError;
+
+        expect(commands).toEqual(["node", "node"]);
       });
 
-      task = yield* spawn(function* () {
-        try {
-          yield* proc;
-        } catch (e) {
-          return e as Error;
-        }
-        return new Error(`this shouldn't happen`);
+      it("propagates the exit and terminates sibling daemons", function* () {
+        expect(error).toBeInstanceOf(DaemonExitError);
+        expect(error.status).toMatchObject({ signal: "SIGTERM" });
+
+        yield* waitForProcessExit(sibling.pid);
+        expect(() => process.kill(sibling.pid, 0)).toThrow();
       });
-
-      const listening = yield* expectMatch(/listening/, lines()(proc.stdout));
-      expect(listening).toBe(true);
-
-      yield* fetchText("http://localhost:29001", {
-        method: "POST",
-        body: "exit",
-      });
-    });
-
-    it("throw an error because it was not expected to close", function* () {
-      yield* until(
-        expect(task).resolves.toHaveProperty("name", "DaemonExitError"),
-      );
-    });
-  });
+    },
+  );
 
   describe("shutting down an effection-based daemon process prematurely", () => {
     let task: Task<void>;
-    let proc: Daemon;
+    let proc: Process;
     beforeEach(function* () {
       const ready = withResolvers<void>();
       task = yield* spawn(function* () {
@@ -117,7 +143,7 @@ describe("daemon", () => {
             cwd: import.meta.dirname,
           });
           ready.resolve();
-          yield* proc;
+          yield* suspend();
         } catch (e) {
           // ignore the error from the process exiting
           //  we just want to check that the finally block runs


### PR DESCRIPTION
# Motivation

`daemon()` is responsible for supervising long-running processes. If a daemon exits while its owning scope is active, it must raise `DaemonExitError` so Effection structured concurrency shuts down sibling operations and processes.

Supervision was placed in the returned daemon handle’s lazy iterator. Callers that only evaluated `yield* daemon(command)` never consumed that iterator, so premature exits went unnoticed.

# Approach

Spawn a supervisor when the daemon is created that raises `DaemonExitError` if the process exits prematurely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Daemon operations now return the managed process directly for simpler process control.
  * Process termination is surfaced through `DaemonExitError`, including when a daemon exits unexpectedly.
  * Related daemon exports were streamlined.

* **Bug Fixes**
  * Improved shutdown handling so sibling daemon processes terminate correctly when one exits prematurely.

* **Chores**
  * Updated `@effectionx/process` to version 0.8.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->