### PR TITLE
feat(context-api): supply a per-call final continuation

### DIFF
--- a/context-api/mod.ts
+++ b/context-api/mod.ts
@@ -32,7 +32,42 @@ export interface Api<A> {
     around: Partial<Around<A>>,
     options?: { at: "min" | "max" },
   ) => Operation<void>;
+  /**
+   * Invoke one operation with the final continuation supplied by this call.
+   *
+   * The same stable-name middleware is collected, in the same `max`/`min`
+   * order, and composed around the continuation given here instead of around
+   * the handler `createApi()` was built with.
+   *
+   * The continuation stays in the caller's own lexical state: it is never
+   * stored, never placed in a context, never part of the operation's public
+   * arguments, and never reachable by the middleware composed around it. A
+   * handler that returns without calling `next` does not reach it, and nested
+   * or concurrent calls each reach their own.
+   *
+   * ```ts
+   * let api = createApi("greet", { *hello(name: string) { return `hi ${name}`; } });
+   *
+   * // Public middleware still runs; this call ends somewhere else.
+   * yield* api.terminating.hello(function* (name) {
+   *   return `HELLO ${name}`;
+   * })("world");
+   * ```
+   */
+  terminating: Terminating<A>;
 }
+
+/**
+ * The per-call terminal form of each function member.
+ *
+ * Value members have no arguments to intercept and no continuation to supply,
+ * so they are not terminable.
+ */
+export type Terminating<A> = {
+  [K in keyof A]: A[K] extends (...args: infer TArgs) => infer TReturn
+    ? (terminal: (...args: TArgs) => TReturn) => Operations<A>[K]
+    : never;
+};
 
 /**
  * Maps each member of an API core to its lifted Operation form.
@@ -104,6 +139,32 @@ export function createApi<A extends {}>(name: string, handler: A): Api<A> {
     {} as Operations<A>,
   );
 
+  let terminating = fields.reduce(
+    (api, field) => {
+      if (typeof handler[field] !== "function") {
+        return api;
+      }
+      return Object.assign(api, {
+        [field]:
+          (terminal: (...args: any[]) => any) =>
+          (...args: any[]) => ({
+            *[Symbol.iterator]() {
+              let scope = yield* useScope();
+              let { max, min } = collectMiddleware(scope, context, field);
+              let stack = combine([...max, ...min]);
+              // Identical to `operations`, except for the base the public stack
+              // is applied to. Collection, ordering and delegation are the same,
+              // so middleware cannot tell which base is underneath it — and
+              // cannot reach it.
+              let result = stack(args, terminal);
+              return isOperation(result) ? yield* result : result;
+            },
+          }),
+      });
+    },
+    {} as Terminating<A>,
+  );
+
   function* around(
     middlewares: Partial<Around<A>>,
     options: { at: "min" | "max" } = { at: "max" },
@@ -132,7 +193,7 @@ export function createApi<A extends {}>(name: string, handler: A): Api<A> {
     scope.set(context, next);
   }
 
-  return { operations, around };
+  return { operations, around, terminating };
 }
 
 function collectMiddleware<A extends {}>(

--- a/context-api/terminating.test.ts
+++ b/context-api/terminating.test.ts
@@ -1,0 +1,302 @@
+import { createApi } from "@effectionx/context-api";
+import { describe, it } from "@effectionx/vitest";
+import {
+  type Operation,
+  scoped,
+  spawn,
+  suspend,
+  withResolvers,
+} from "effection";
+import { expect } from "expect";
+
+/**
+ * `terminating` composes the same public middleware as `operations`, around a
+ * final continuation the caller supplies for that one call.
+ *
+ * The distinction it exists for: the stable name composes replaceable policy,
+ * while the base of the chain belongs to whoever started the call. Middleware
+ * cannot tell the two apart, and cannot reach the base of either.
+ */
+describe("context api: per-call terminal", () => {
+  it("still terminates in the createApi default when none is supplied", function* () {
+    let api = createApi("numbers", {
+      *one(): Operation<number> {
+        return 1;
+      },
+    });
+
+    expect(yield* api.operations.one()).toEqual(1);
+  });
+
+  it("replaces the default for that call only", function* () {
+    let api = createApi("numbers", {
+      *one(): Operation<number> {
+        return 1;
+      },
+    });
+
+    expect(
+      yield* api.terminating.one(function* (): Operation<number> {
+        return 99;
+      })(),
+    ).toEqual(99);
+    // The next ordinary call is unaffected.
+    expect(yield* api.operations.one()).toEqual(1);
+  });
+
+  it("collects the same middleware, in the same max/min order, either way", function* () {
+    let order: string[] = [];
+    let api = createApi("numbers", {
+      *one(): Operation<string> {
+        order.push("default");
+        return "default";
+      },
+    });
+
+    yield* scoped(function* () {
+      yield* api.around({
+        *one([], next) {
+          order.push("outer");
+          return yield* next();
+        },
+      });
+      yield* api.around(
+        {
+          *one([], next) {
+            order.push("inner");
+            return yield* next();
+          },
+        },
+        { at: "min" },
+      );
+
+      order.length = 0;
+      yield* api.operations.one();
+      expect(order).toEqual(["outer", "inner", "default"]);
+
+      order.length = 0;
+      yield* api.terminating.one(function* (): Operation<string> {
+        order.push("supplied");
+        return "supplied";
+      })();
+      expect(order).toEqual(["outer", "inner", "supplied"]);
+    });
+  });
+
+  it("does not reach the continuation when a handler declines to delegate", function* () {
+    let reached: string[] = [];
+    let api = createApi("numbers", {
+      *one(): Operation<string> {
+        return "default";
+      },
+    });
+
+    let answer = yield* scoped(function* () {
+      yield* api.around({
+        // deno-lint-ignore require-yield
+        *one() {
+          return "refused";
+        },
+      });
+      return yield* api.terminating.one(function* (): Operation<string> {
+        reached.push("supplied");
+        return "supplied";
+      })();
+    });
+
+    expect(answer).toEqual("refused");
+    expect(reached).toEqual([]);
+  });
+
+  it("gives nested calls their own continuations", function* () {
+    let api = createApi("numbers", {
+      *one(): Operation<string> {
+        return "default";
+      },
+    });
+
+    let seen: string[] = [];
+    let nested = false;
+    yield* scoped(function* () {
+      yield* api.around({
+        *one([], next) {
+          // A nested call started from inside the outer call's own chain — the
+          // shape that matters, since the nested chain collects this very
+          // middleware. The guard is what stops it recursing forever; what is
+          // under test is that each call reaches its own continuation.
+          if (!nested) {
+            nested = true;
+            seen.push(
+              yield* api.terminating.one(function* (): Operation<string> {
+                return "inner-terminal";
+              })(),
+            );
+          }
+          return yield* next();
+        },
+      });
+      seen.push(
+        yield* api.terminating.one(function* (): Operation<string> {
+          return "outer-terminal";
+        })(),
+      );
+    });
+
+    expect(seen).toEqual(["inner-terminal", "outer-terminal"]);
+  });
+
+  it("keeps concurrent calls from exchanging continuations", function* () {
+    let api = createApi("numbers", {
+      *one(): Operation<string> {
+        return "default";
+      },
+    });
+
+    let answers = yield* scoped(function* () {
+      let first = yield* spawn(() =>
+        api.terminating.one(function* (): Operation<string> {
+          return "first";
+        })(),
+      );
+      let second = yield* spawn(() =>
+        api.terminating.one(function* (): Operation<string> {
+          return "second";
+        })(),
+      );
+      return [yield* first, yield* second];
+    });
+
+    expect(answers).toEqual(["first", "second"]);
+  });
+
+  it("composes middleware installed through another descriptor of the same name", function* () {
+    let seen: string[] = [];
+    let api = createApi("numbers", {
+      *one(): Operation<string> {
+        return "default";
+      },
+    });
+    // A separately constructed descriptor of the same stable name, which is
+    // what a second loaded copy of a package is.
+    let elsewhere = createApi("numbers", {
+      *one(): Operation<string> {
+        return "elsewhere-default";
+      },
+    });
+
+    let answer = yield* scoped(function* () {
+      yield* elsewhere.around({
+        *one([], next) {
+          seen.push("foreign");
+          return yield* next();
+        },
+      });
+      return yield* api.terminating.one(function* (): Operation<string> {
+        return "supplied";
+      })();
+    });
+
+    expect(seen).toEqual(["foreign"]);
+    expect(answer).toEqual("supplied");
+  });
+
+  it("keeps later at:min and at:max registrations outside the supplied terminal", function* () {
+    let order: string[] = [];
+    let api = createApi("numbers", {
+      *one(): Operation<string> {
+        return "default";
+      },
+    });
+
+    yield* scoped(function* () {
+      yield* api.around(
+        {
+          *one([], next) {
+            order.push("min");
+            return yield* next();
+          },
+        },
+        { at: "min" },
+      );
+      yield* api.around(
+        {
+          *one([], next) {
+            order.push("max");
+            return yield* next();
+          },
+        },
+        { at: "max" },
+      );
+
+      yield* api.terminating.one(function* (): Operation<string> {
+        order.push("terminal");
+        return "supplied";
+      })();
+    });
+
+    // Both public layers ran, and both ran outside the supplied terminal.
+    expect(order).toEqual(["max", "min", "terminal"]);
+  });
+
+  it("tears the call down normally when the continuation fails", function* () {
+    let api = createApi("numbers", {
+      *one(): Operation<string> {
+        return "default";
+      },
+    });
+
+    let unwound: string[] = [];
+    let failure = yield* scoped(function* () {
+      yield* api.around({
+        *one([], next) {
+          try {
+            return yield* next();
+          } finally {
+            unwound.push("middleware");
+          }
+        },
+      });
+      try {
+        yield* api.terminating.one(function* (): Operation<string> {
+          throw new Error("the continuation failed");
+        })();
+        return undefined;
+      } catch (error) {
+        return error;
+      }
+    });
+
+    expect(String(failure)).toContain("the continuation failed");
+    expect(unwound).toEqual(["middleware"]);
+  });
+
+  it("tears the call down normally when the caller is halted", function* () {
+    let api = createApi("numbers", {
+      *one(): Operation<string> {
+        return "default";
+      },
+    });
+    let unwound: string[] = [];
+
+    // The continuation says when it is running, so the halt lands inside it by
+    // construction rather than by winning a race against the scheduler.
+    let started = withResolvers<void>();
+    yield* scoped(function* () {
+      let task = yield* spawn(() =>
+        api.terminating.one(function* (): Operation<string> {
+          try {
+            started.resolve();
+            yield* suspend();
+            return "never";
+          } finally {
+            unwound.push("terminal");
+          }
+        })(),
+      );
+      yield* started.operation;
+      yield* task.halt();
+    });
+
+    expect(unwound).toEqual(["terminal"]);
+  });
+});


### PR DESCRIPTION
## Why

`createApi()` composes stable-name middleware around the handler it was built with, and that handler is the only base a call can end in. `Api` exposes `operations` and `around` and nothing else, so a caller that owns the authority for one invocation has nowhere to put it — the base is shared, and anything that reaches it is reachable by every other call through the same name.

This is a prerequisite for [taras/executable.md#432](https://github.com/taras/executable.md/pull/432), where the public `Execution` name has to keep composing replaceable policy while the final continuation carries authority for exactly one invocation. Without this the only routes are installing the terminal as `at:"min"` middleware — which is still replaceable — or reproducing `collectMiddleware`, `$api:$name`, `contextWindow()` and `reducePrototypeChain()` in the consumer, which couples it to internals of this package and of Effection.

## What

```ts
api.terminating.hello(function* (name) {
  return `HELLO ${name}`;
})("world");
```

`terminating` mirrors `operations` for function members. It collects the same middleware, preserves `max`/`min` ordering exactly, and composes it around the continuation supplied for that call instead of the `createApi()` handler.

The continuation stays in the caller's lexical state: it is not stored, not placed in a context, not part of the operation's public arguments, not behind a stable name, and not reachable by the middleware composed around it. Middleware cannot tell which base is underneath it.

Value members have no arguments to intercept and no continuation to supply, so they are typed `never`.

## Compatibility

`operations` and the module-level default are untouched — additive only. Loaded-copy composition is unchanged, because collection still goes through the same stable-name middleware context.

## Tests

`context-api/terminating.test.ts`, 10 cases:

1. existing operations still terminate in the `createApi` default
2. a per-call continuation replaces the default for that call only
3. public middleware observes the same `max`/`min` order with either terminal
4. a non-delegating handler prevents the supplied continuation from running
5. nested calls use their respective continuations — including one started from inside the outer call's own chain
6. concurrent calls cannot exchange continuations
7. middleware installed through another same-name descriptor composes
8. later `at:"min"` and `at:"max"` registrations remain public layers outside the supplied continuation
9. failure tears the call down normally
10. cancellation tears the call down normally

`cd context-api && npx vitest run` → 49 passed (3 files), which includes the package's existing suites unchanged.