### PR TITLE
📝 Describe the test runner this repo actually uses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ When working in this repository:
 - **Package Manager**: pnpm 9.15.9
 - **Build**: TypeScript 5+, Turbo
 - **Linting/Formatting**: Biome
-- **Testing**: Node.js test runner
+- **Testing**: Vitest, via the `@effectionx/vitest` adapter
 
 ## Code Review Policies
 
@@ -100,7 +100,7 @@ Each package requires:
 ├── mod.ts            # Main entry point (exports public API)
 ├── package.json      # Package manifest with peerDependencies
 ├── tsconfig.json     # Extends root tsconfig
-├── *.test.ts         # Tests using Node.js test runner
+├── *.test.ts         # Tests using @effectionx/vitest
 └── README.md         # Documentation (text before --- used as description)
 ```
 
@@ -115,16 +115,22 @@ Each package requires:
 
 ### Test Files
 
-- Use Node.js test runner (`node --test`)
-- Import test utilities from `@effectionx/bdd` when needed
+- Import `describe`/`it` from `@effectionx/vitest`, which runs Effection
+  operations as tests. This is what new packages should use
+- `bdd` and `inline` are the two exceptions. Both are excluded from Vitest in
+  `vitest.config.ts`, import `@effectionx/bdd`, and run under `node --test` via
+  `pnpm test:node`
 - Tests run with `--env-file=../.env`
+- Do not use `sleep()` to wait for a result — see the
+  [No-Sleep Test Synchronization policy](.policies/no-sleep-test-sync.md)
 
 ## Commands
 
 ```bash
 pnpm build          # Build all packages (TypeScript + bundling)
 pnpm build:tsc      # Build TypeScript only
-pnpm test           # Run all tests
+pnpm test           # Run all tests (vitest)
+pnpm test:node      # Run the bdd and inline suites under node --test
 pnpm test:matrix    # Test against peer dependency versions
 pnpm check          # Type-check all packages
 pnpm lint           # Lint all packages


### PR DESCRIPTION
## Motivation

`AGENTS.md` says tests use the Node.js test runner. They mostly don't, and
haven't for a while:

| runner | suites |
| --- | --- |
| `@effectionx/vitest` | 51 |
| `@effectionx/bdd` under `node --test` | 4 (`bdd`, `inline`) |

The `@effectionx/vitest` adapter landed on 2026-01-18 in `8e452a5`. The testing
text was carried over verbatim from `CLAUDE.md` two weeks later in `60df902` and
never revised, so it still describes what came before.

This is not just stale prose. CodeRabbit treats `AGENTS.md` as its coding
guidelines, so it has been asking every new package to migrate off
`@effectionx/vitest` — on #235, again on #242, and it will keep doing so. Acting
on that advice would move new packages onto a runner that 51 of 55 suites do not
use.

## Approach

Describe the split that exists:

- Vitest via `@effectionx/vitest` is the standard, and what new packages use.
- `bdd` and `inline` are the two exceptions. Both are excluded from Vitest in
  `vitest.config.ts` and run under `node --test` via `pnpm test:node`.

Also add `pnpm test:node` to the command list — CI runs it, but it was missing —
and link the No-Sleep Test Synchronization policy from where test files are
described, since that is where someone writing a test will be looking.

## Impact

Documentation only; no code, no tests, no package manifests. New packages get
pointed at the runner everything else uses, and the recurring review comment
should stop.

## Validation

Every claim checked against the tree rather than assumed:

- `pnpm test` resolves to vitest, `pnpm test:node` to
  `node --test "bdd/*.test.ts" "inline/*.test.ts"`
- `vitest.config.ts` excludes `**/bdd/**` and `**/inline/**`
- the four `@effectionx/bdd` importers are `bdd/bdd.test.ts` and the three
  `inline/*.test.ts` suites
