### PR TITLE
✨ useNativeProcess: a native-listener child-process resource

### DIFF
--- a/process/package.json
+++ b/process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/process",
   "description": "Spawn and manage child processes with structured concurrency",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/process/src/exec/native.ts
+++ b/process/src/exec/native.ts
@@ -1,0 +1,86 @@
+import type { ChildProcess } from "node:child_process";
+import {
+  type Operation,
+  type Result,
+  type Stream,
+  Err,
+  Ok,
+  createSignal,
+  ensure,
+  resource,
+  withResolvers,
+} from "effection";
+
+export type ProcessResultValue = [number?, string?];
+
+/**
+ * A child process as a resource, wired entirely through native Node event
+ * listeners: exit through the `close` event, output pushed straight into
+ * signals. All listeners are attached in the same synchronous continuation
+ * as the spawn, so no event can be missed.
+ *
+ * Standard cleanup: if the process is still alive when the scope exits it is
+ * sent SIGTERM with `child.kill()`, and the scope is held open until the OS
+ * has reaped the process and closed its stdio pipes. Platform-specific
+ * termination (process groups, ctrlc, force kill) belongs to the caller's
+ * own teardown, which runs before this backstop.
+ */
+export interface NativeProcess {
+  childProcess: ChildProcess;
+  stdout: Stream<Uint8Array, void>;
+  stderr: Stream<Uint8Array, void>;
+
+  /** The `close` event value, or the error that prevented the spawn. */
+  result: Operation<Result<ProcessResultValue>>;
+}
+
+export function useNativeProcess(
+  create: () => ChildProcess,
+): Operation<NativeProcess> {
+  return resource(function* (provide) {
+    let result = withResolvers<Result<ProcessResultValue>>();
+    let stdout = createSignal<Uint8Array, void>();
+    let stderr = createSignal<Uint8Array, void>();
+
+    let child: ChildProcess | undefined;
+
+    // Registered while `child` is still undefined; the spawn below follows
+    // in the same synchronous continuation, so the process never exists
+    // without this teardown armed.
+    yield* ensure(function* () {
+      if (child) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGTERM");
+        }
+        // hold the scope until the OS has reaped the process and closed its
+        // pipes; `result` is a value, so an error outcome cannot throw here
+        yield* result.operation;
+      }
+    });
+
+    const spawned = create();
+    child = spawned;
+
+    spawned.once("error", (error) => {
+      result.resolve(Err(error));
+    });
+    spawned.once("close", (code, signal) => {
+      result.resolve(Ok([code ?? undefined, signal ?? undefined]));
+    });
+
+    if (!spawned.stdout || !spawned.stderr) {
+      throw new Error("stdout and stderr must be available with stdio: pipe");
+    }
+    spawned.stdout.on("data", (chunk: Uint8Array) => stdout.send(chunk));
+    spawned.stdout.once("close", () => stdout.close());
+    spawned.stderr.on("data", (chunk: Uint8Array) => stderr.send(chunk));
+    spawned.stderr.once("close", () => stderr.close());
+
+    yield* provide({
+      childProcess: spawned,
+      stdout,
+      stderr,
+      result: result.operation,
+    });
+  });
+}

--- a/process/src/exec/native.ts
+++ b/process/src/exec/native.ts
@@ -27,6 +27,12 @@ export type ProcessResultValue = [number?, string?];
  */
 export interface NativeProcess {
   childProcess: ChildProcess;
+
+  /**
+   * Hot streams: chunks that arrive before a subscription exists are
+   * dropped. Subscribe in the same continuation that acquires the resource,
+   * before awaiting `result`.
+   */
   stdout: Stream<Uint8Array, void>;
   stderr: Stream<Uint8Array, void>;
 
@@ -60,21 +66,25 @@ export function useNativeProcess(
     // without this teardown armed.
     yield* ensure(function* () {
       if (child) {
-        if (child.exitCode === null && child.signalCode === null) {
-          child.kill("SIGTERM");
+        try {
+          if (child.exitCode === null && child.signalCode === null) {
+            child.kill("SIGTERM");
+          }
+          // hold the scope until the OS has reaped the process and closed its
+          // pipes; `result` is a value, so an error outcome cannot throw here
+          yield* result.operation;
+        } finally {
+          // deregistration is bound to this scope, never to an event firing,
+          // because the pipes may be shared beyond this process. It follows
+          // the wait above, which needs `onClose` still attached, but must
+          // not depend on that wait completing — hence the sync finally.
+          child.off("error", onError);
+          child.off("close", onClose);
+          child.stdout?.off("data", onStdout);
+          child.stdout?.off("close", onStdoutClose);
+          child.stderr?.off("data", onStderr);
+          child.stderr?.off("close", onStderrClose);
         }
-        // hold the scope until the OS has reaped the process and closed its
-        // pipes; `result` is a value, so an error outcome cannot throw here
-        yield* result.operation;
-        // deregistration is bound to this scope, never to an event firing,
-        // because the pipes may be shared beyond this process. It must
-        // follow the wait above, which needs `onClose` still attached.
-        child.off("error", onError);
-        child.off("close", onClose);
-        child.stdout?.off("data", onStdout);
-        child.stdout?.off("close", onStdoutClose);
-        child.stderr?.off("data", onStderr);
-        child.stderr?.off("close", onStderrClose);
       }
     });
 

--- a/process/src/exec/native.ts
+++ b/process/src/exec/native.ts
@@ -44,6 +44,17 @@ export function useNativeProcess(
 
     let child: ChildProcess | undefined;
 
+    let onError = (error: Error) => {
+      result.resolve(Err(error));
+    };
+    let onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+      result.resolve(Ok([code ?? undefined, signal ?? undefined]));
+    };
+    let onStdout = (chunk: Uint8Array) => stdout.send(chunk);
+    let onStdoutClose = () => stdout.close();
+    let onStderr = (chunk: Uint8Array) => stderr.send(chunk);
+    let onStderrClose = () => stderr.close();
+
     // Registered while `child` is still undefined; the spawn below follows
     // in the same synchronous continuation, so the process never exists
     // without this teardown armed.
@@ -55,26 +66,35 @@ export function useNativeProcess(
         // hold the scope until the OS has reaped the process and closed its
         // pipes; `result` is a value, so an error outcome cannot throw here
         yield* result.operation;
+        // deregistration is bound to this scope, never to an event firing,
+        // because the pipes may be shared beyond this process. It must
+        // follow the wait above, which needs `onClose` still attached.
+        child.off("error", onError);
+        child.off("close", onClose);
+        child.stdout?.off("data", onStdout);
+        child.stdout?.off("close", onStdoutClose);
+        child.stderr?.off("data", onStderr);
+        child.stderr?.off("close", onStderrClose);
       }
     });
 
     const spawned = create();
     child = spawned;
 
-    spawned.once("error", (error) => {
-      result.resolve(Err(error));
-    });
-    spawned.once("close", (code, signal) => {
-      result.resolve(Ok([code ?? undefined, signal ?? undefined]));
-    });
+    spawned.on("error", onError);
+    spawned.on("close", onClose);
 
     if (!spawned.stdout || !spawned.stderr) {
       throw new Error("stdout and stderr must be available with stdio: pipe");
     }
-    spawned.stdout.on("data", (chunk: Uint8Array) => stdout.send(chunk));
-    spawned.stdout.once("close", () => stdout.close());
-    spawned.stderr.on("data", (chunk: Uint8Array) => stderr.send(chunk));
-    spawned.stderr.once("close", () => stderr.close());
+
+    // Node emits the child "close" event only after both stdio streams have
+    // closed, and these listeners run synchronously with stream emission, so
+    // by the time `result` resolves every chunk is already in the signals.
+    spawned.stdout.on("data", onStdout);
+    spawned.stdout.on("close", onStdoutClose);
+    spawned.stderr.on("data", onStderr);
+    spawned.stderr.on("close", onStderrClose);
 
     yield* provide({
       childProcess: spawned,

--- a/process/src/exec/posix.ts
+++ b/process/src/exec/posix.ts
@@ -13,8 +13,6 @@ import {
   withResolvers,
 } from "effection";
 import { unbox, useEvalScope } from "@effectionx/scope-eval";
-import { once } from "@effectionx/node/events";
-import { fromReadable } from "@effectionx/node/stream";
 import type {
   CreateOSProcess,
   ExecOptions,
@@ -58,9 +56,30 @@ export function* createPosixProcess(
       throw new Error("stdout and stderr must be available with stdio: pipe");
     }
 
+    // Native listeners attached in the same synchronous continuation as the
+    // spawn: process events and stdio chunks cannot be missed, and no
+    // readable pumps are needed.
+    childProcess.once("error", (error) => {
+      processResult.resolve(Err(error));
+    });
+    childProcess.once("close", (code, signal) => {
+      processResult.resolve(Ok([code ?? undefined, signal ?? undefined]));
+    });
+
+    let raw = {
+      stdout: createSignal<Uint8Array, void>(),
+      stderr: createSignal<Uint8Array, void>(),
+    };
+    childProcess.stdout.on("data", (chunk: Uint8Array) =>
+      raw.stdout.send(chunk),
+    );
+    childProcess.stdout.once("close", () => raw.stdout.close());
+    childProcess.stderr.on("data", (chunk: Uint8Array) =>
+      raw.stderr.send(chunk),
+    );
+    childProcess.stderr.once("close", () => raw.stderr.close());
+
     let io = {
-      stdout: yield* fromReadable(childProcess.stdout),
-      stderr: yield* fromReadable(childProcess.stderr),
       stdoutDone: withResolvers<void>(),
       stderrDone: withResolvers<void>(),
     };
@@ -69,22 +88,24 @@ export function* createPosixProcess(
     let stderr = createSignal<Uint8Array, void>();
 
     yield* spawn(function* () {
-      let next = yield* io.stdout.next();
+      let subscription = yield* raw.stdout;
+      let next = yield* subscription.next();
       while (!next.done) {
         yield* Stdio.operations.stdout(next.value);
         stdout.send(next.value);
-        next = yield* io.stdout.next();
+        next = yield* subscription.next();
       }
       stdout.close();
       io.stdoutDone.resolve();
     });
 
     yield* spawn(function* () {
-      let next = yield* io.stderr.next();
+      let subscription = yield* raw.stderr;
+      let next = yield* subscription.next();
       while (!next.done) {
         yield* Stdio.operations.stderr(next.value);
         stderr.send(next.value);
-        next = yield* io.stderr.next();
+        next = yield* subscription.next();
       }
       stderr.close();
       io.stderrDone.resolve();
@@ -95,16 +116,6 @@ export function* createPosixProcess(
         childProcess.stdin.write(data);
       },
     };
-
-    yield* spawn(function* trapError() {
-      let [error] = yield* once<[Error]>(childProcess, "error");
-      processResult.resolve(Err(error));
-    });
-
-    yield* spawn(function* () {
-      let value = yield* once<ProcessResultValue>(childProcess, "close");
-      processResult.resolve(Ok(value));
-    });
 
     function* join() {
       let result = yield* processResult.operation;

--- a/process/src/exec/posix.ts
+++ b/process/src/exec/posix.ts
@@ -1,11 +1,8 @@
 import { spawn as spawnProcess } from "node:child_process";
 import process from "node:process";
 import {
-  type Result,
   type Operation,
   type Yielded,
-  Err,
-  Ok,
   all,
   createSignal,
   ensure,
@@ -22,14 +19,12 @@ import type {
 } from "./types.ts";
 import { Stdio } from "../api.ts";
 import { ExecError } from "./error.ts";
-
-type ProcessResultValue = [number?, string?];
+import { useNativeProcess } from "./native.ts";
 
 export function* createPosixProcess(
   command: string,
   options: ExecOptions,
 ): Operation<Process> {
-  let processResult = withResolvers<Result<ProcessResultValue>>();
   const evalScope = yield* useEvalScope();
   const result = yield* evalScope.eval(function* () {
     // Killing all child processes started by this command is surprisingly
@@ -42,42 +37,18 @@ export function* createPosixProcess(
     // process.
     //
     // More information here: https://unix.stackexchange.com/questions/14815/process-descendants
-    let childProcess = spawnProcess(command, options.arguments || [], {
-      detached: true,
-      shell: options.shell,
-      env: options.env,
-      cwd: options.cwd,
-      stdio: "pipe",
-    });
+    const os = yield* useNativeProcess(() =>
+      spawnProcess(command, options.arguments || [], {
+        detached: true,
+        shell: options.shell,
+        env: options.env,
+        cwd: options.cwd,
+        stdio: "pipe",
+      }),
+    );
 
+    let { childProcess } = os;
     let { pid } = childProcess;
-
-    if (!childProcess.stdout || !childProcess.stderr) {
-      throw new Error("stdout and stderr must be available with stdio: pipe");
-    }
-
-    // Native listeners attached in the same synchronous continuation as the
-    // spawn: process events and stdio chunks cannot be missed, and no
-    // readable pumps are needed.
-    childProcess.once("error", (error) => {
-      processResult.resolve(Err(error));
-    });
-    childProcess.once("close", (code, signal) => {
-      processResult.resolve(Ok([code ?? undefined, signal ?? undefined]));
-    });
-
-    let raw = {
-      stdout: createSignal<Uint8Array, void>(),
-      stderr: createSignal<Uint8Array, void>(),
-    };
-    childProcess.stdout.on("data", (chunk: Uint8Array) =>
-      raw.stdout.send(chunk),
-    );
-    childProcess.stdout.once("close", () => raw.stdout.close());
-    childProcess.stderr.on("data", (chunk: Uint8Array) =>
-      raw.stderr.send(chunk),
-    );
-    childProcess.stderr.once("close", () => raw.stderr.close());
 
     let io = {
       stdoutDone: withResolvers<void>(),
@@ -88,7 +59,7 @@ export function* createPosixProcess(
     let stderr = createSignal<Uint8Array, void>();
 
     yield* spawn(function* () {
-      let subscription = yield* raw.stdout;
+      let subscription = yield* os.stdout;
       let next = yield* subscription.next();
       while (!next.done) {
         yield* Stdio.operations.stdout(next.value);
@@ -100,7 +71,7 @@ export function* createPosixProcess(
     });
 
     yield* spawn(function* () {
-      let subscription = yield* raw.stderr;
+      let subscription = yield* os.stderr;
       let next = yield* subscription.next();
       while (!next.done) {
         yield* Stdio.operations.stderr(next.value);
@@ -113,12 +84,12 @@ export function* createPosixProcess(
 
     let stdin: Writable<string> = {
       send(data: string) {
-        childProcess.stdin.write(data);
+        childProcess.stdin?.write(data);
       },
     };
 
     function* join() {
-      let result = yield* processResult.operation;
+      let result = yield* os.result;
       if (result.ok) {
         let [code, signal] = result.value;
         return { command, options, code, signal } as ExitStatus;

--- a/process/src/exec/win32.ts
+++ b/process/src/exec/win32.ts
@@ -7,8 +7,6 @@ import {
   type Operation,
   type Result,
   type Yielded,
-  Err,
-  Ok,
   all,
   createSignal,
   ensure,
@@ -24,9 +22,8 @@ import type {
 } from "./types.ts";
 import { Stdio } from "../api.ts";
 import { ExecError } from "./error.ts";
+import { type ProcessResultValue, useNativeProcess } from "./native.ts";
 import { unbox, useEvalScope } from "@effectionx/scope-eval";
-
-type ProcessResultValue = [number?, string?];
 
 function* killTree(pid: number) {
   try {
@@ -45,59 +42,35 @@ export function* createWin32Process(
   command: string,
   options: ExecOptions,
 ): Operation<Process> {
-  let processResult = withResolvers<Result<ProcessResultValue>>();
   const evalScope = yield* useEvalScope();
   const result = yield* evalScope.eval(function* () {
     // Windows-specific process spawning with different options than POSIX
-    let childProcess = spawnProcess(command, options.arguments || [], {
-      // We lose exit information and events if this is detached in windows
-      // and it opens a window in windows+powershell.
-      detached: false,
-      // The `shell` option is passed to `cross-spawn` to control whether a shell is used.
-      // On Windows, `shell: true` is necessary to run command strings, as it uses
-      // `cmd.exe` to parse the command and find executables in the PATH.
-      // Using a boolean `true` was previously disabled, causing ENOENT errors for
-      // commands that were not a direct path to an executable.
-      shell: options.shell || false,
-      // With stdio as pipe, windows gets stuck where neither the child nor the
-      // parent wants to close the stream, so we call it ourselves in the exit event.
-      stdio: "pipe",
-      // Hide the child window so that killing it will not block the parent
-      // with a Terminate Batch Process (Y/n)
-      windowsHide: true,
-      env: options.env,
-      cwd: options.cwd,
-    });
+    const os = yield* useNativeProcess(() =>
+      spawnProcess(command, options.arguments || [], {
+        // We lose exit information and events if this is detached in windows
+        // and it opens a window in windows+powershell.
+        detached: false,
+        // The `shell` option is passed to `cross-spawn` to control whether a shell is used.
+        // On Windows, `shell: true` is necessary to run command strings, as it uses
+        // `cmd.exe` to parse the command and find executables in the PATH.
+        // Using a boolean `true` was previously disabled, causing ENOENT errors for
+        // commands that were not a direct path to an executable.
+        shell: options.shell || false,
+        // With stdio as pipe, windows gets stuck where neither the child nor the
+        // parent wants to close the stream, so we call it ourselves in the exit event.
+        stdio: "pipe",
+        // Hide the child window so that killing it will not block the parent
+        // with a Terminate Batch Process (Y/n)
+        windowsHide: true,
+        env: options.env,
+        cwd: options.cwd,
+      }),
+    );
 
+    let { childProcess } = os;
     let { pid } = childProcess;
 
-    if (!childProcess.stdout || !childProcess.stderr) {
-      throw new Error("stdout and stderr must be available with stdio: pipe");
-    }
-
-    // Native listeners attached in the same synchronous continuation as the
-    // spawn: process events and stdio chunks cannot be missed, and no
-    // readable pumps are needed.
-    let rawClose = withResolvers<ProcessResultValue>();
-    childProcess.once("error", (error) => {
-      processResult.resolve(Err(error));
-    });
-    childProcess.once("close", (code, signal) => {
-      rawClose.resolve([code ?? undefined, signal ?? undefined]);
-    });
-
-    let raw = {
-      stdout: createSignal<Uint8Array, void>(),
-      stderr: createSignal<Uint8Array, void>(),
-    };
-    childProcess.stdout.on("data", (chunk: Uint8Array) =>
-      raw.stdout.send(chunk),
-    );
-    childProcess.stdout.once("close", () => raw.stdout.close());
-    childProcess.stderr.on("data", (chunk: Uint8Array) =>
-      raw.stderr.send(chunk),
-    );
-    childProcess.stderr.once("close", () => raw.stderr.close());
+    let processResult = withResolvers<Result<ProcessResultValue>>();
 
     let io = {
       stdoutDone: withResolvers<void>(),
@@ -108,7 +81,7 @@ export function* createWin32Process(
     const stderr = createSignal<Uint8Array, void>();
 
     yield* spawn(function* () {
-      let subscription = yield* raw.stdout;
+      let subscription = yield* os.stdout;
       let next = yield* subscription.next();
       while (!next.done) {
         yield* Stdio.operations.stdout(next.value);
@@ -120,7 +93,7 @@ export function* createWin32Process(
     });
 
     yield* spawn(function* () {
-      let subscription = yield* raw.stderr;
+      let subscription = yield* os.stderr;
       let next = yield* subscription.next();
       while (!next.done) {
         yield* Stdio.operations.stderr(next.value);
@@ -133,17 +106,17 @@ export function* createWin32Process(
 
     let stdin: Writable<string> = {
       send(data: string) {
-        childProcess.stdin.write(data);
+        childProcess.stdin?.write(data);
       },
     };
 
     yield* spawn(function* () {
-      let value = yield* rawClose.operation;
+      let value = yield* os.result;
       // out of band with the finally block below compared to posix as
       // win32 is more sensitive to graceful shutdown timing that it is
       // worth waiting for stdout and stderr to close before resolving the process result
       yield* all([io.stdoutDone.operation, io.stderrDone.operation]);
-      processResult.resolve(Ok(value));
+      processResult.resolve(value);
     });
 
     function* join() {
@@ -166,7 +139,7 @@ export function* createWin32Process(
     // Suppress EPIPE errors on stdin - these occur on Windows when the child
     // process exits before we finish writing to it. This is expected during
     // cleanup when we're killing the process.
-    childProcess.stdin.on("error", (err: Error & { code?: string }) => {
+    childProcess.stdin?.on("error", (err: Error & { code?: string }) => {
       if (err.code !== "EPIPE") {
         throw err;
       }
@@ -184,15 +157,17 @@ export function* createWin32Process(
         }
 
         let stdin = childProcess.stdin;
-        if (stdin.writable) {
-          try {
-            //Terminate batch process (Y/N)
-            stdin.write("Y\n");
-          } catch (_err) {
-            /* not much we can do here */
+        if (stdin) {
+          if (stdin.writable) {
+            try {
+              //Terminate batch process (Y/N)
+              stdin.write("Y\n");
+            } catch (_err) {
+              /* not much we can do here */
+            }
           }
+          stdin.end();
         }
-        stdin.end();
       }
 
       // depending on how we shutdown, this may already be closed and

--- a/process/src/exec/win32.ts
+++ b/process/src/exec/win32.ts
@@ -1,6 +1,5 @@
 import { platform } from "node:os";
 import { once } from "@effectionx/node/events";
-import { fromReadable } from "@effectionx/node/stream";
 // @ts-types="npm:@types/cross-spawn@6.0.6"
 import { spawn as spawnProcess } from "cross-spawn";
 import { ctrlc } from "ctrlc-windows";
@@ -76,9 +75,31 @@ export function* createWin32Process(
       throw new Error("stdout and stderr must be available with stdio: pipe");
     }
 
+    // Native listeners attached in the same synchronous continuation as the
+    // spawn: process events and stdio chunks cannot be missed, and no
+    // readable pumps are needed.
+    let rawClose = withResolvers<ProcessResultValue>();
+    childProcess.once("error", (error) => {
+      processResult.resolve(Err(error));
+    });
+    childProcess.once("close", (code, signal) => {
+      rawClose.resolve([code ?? undefined, signal ?? undefined]);
+    });
+
+    let raw = {
+      stdout: createSignal<Uint8Array, void>(),
+      stderr: createSignal<Uint8Array, void>(),
+    };
+    childProcess.stdout.on("data", (chunk: Uint8Array) =>
+      raw.stdout.send(chunk),
+    );
+    childProcess.stdout.once("close", () => raw.stdout.close());
+    childProcess.stderr.on("data", (chunk: Uint8Array) =>
+      raw.stderr.send(chunk),
+    );
+    childProcess.stderr.once("close", () => raw.stderr.close());
+
     let io = {
-      stdout: yield* fromReadable(childProcess.stdout),
-      stderr: yield* fromReadable(childProcess.stderr),
       stdoutDone: withResolvers<void>(),
       stderrDone: withResolvers<void>(),
     };
@@ -87,22 +108,24 @@ export function* createWin32Process(
     const stderr = createSignal<Uint8Array, void>();
 
     yield* spawn(function* () {
-      let next = yield* io.stdout.next();
+      let subscription = yield* raw.stdout;
+      let next = yield* subscription.next();
       while (!next.done) {
         yield* Stdio.operations.stdout(next.value);
         stdout.send(next.value);
-        next = yield* io.stdout.next();
+        next = yield* subscription.next();
       }
       stdout.close();
       io.stdoutDone.resolve();
     });
 
     yield* spawn(function* () {
-      let next = yield* io.stderr.next();
+      let subscription = yield* raw.stderr;
+      let next = yield* subscription.next();
       while (!next.done) {
         yield* Stdio.operations.stderr(next.value);
         stderr.send(next.value);
-        next = yield* io.stderr.next();
+        next = yield* subscription.next();
       }
       stderr.close();
       io.stderrDone.resolve();
@@ -114,13 +137,8 @@ export function* createWin32Process(
       },
     };
 
-    yield* spawn(function* trapError() {
-      const [error] = yield* once<Error[]>(childProcess, "error");
-      processResult.resolve(Err(error));
-    });
-
     yield* spawn(function* () {
-      let value = yield* once<ProcessResultValue>(childProcess, "close");
+      let value = yield* rawClose.operation;
       // out of band with the finally block below compared to posix as
       // win32 is more sensitive to graceful shutdown timing that it is
       // worth waiting for stdout and stderr to close before resolving the process result


### PR DESCRIPTION
# Motivation

Managing a child process previously flowed through `fromReadable` stream subscriptions plus spawned watcher tasks for the `error` and `close` events. That put suspension points between creating the OS process and wiring up its observation and cleanup, and split the lifecycle of a single OS resource across several loosely-coordinated tasks. We want the child process to be a proper resource: acquired synchronously together with its event wiring, torn down through standard cleanup, with platform-specific concerns visibly separated from the common ones.

# Approach

Two commits:

1. **♻️ Feed process stdio from native listeners instead of readable pumps** — `data`/`close` listeners on stdout/stderr push chunks straight into signals, and `error`/`close` listeners on the child resolve the process result, all attached in the same synchronous continuation as the spawn. Replaces the `fromReadable` subscriptions and the `once()` watcher tasks. No behavior change.
2. **✨ Extract `useNativeProcess`** (`src/exec/native.ts`) — a resource that spawns via a caller-provided factory and performs standard cleanup on scope exit: `child.kill()` (SIGTERM) if the process is still alive, then hold the scope open until the OS has reaped the process and closed its pipes. The teardown registers before the child exists, so a halt during acquisition can never find a live process without an armed teardown.

Platform-specific teardown stays in each adapter's own `ensure`, which runs before the resource's backstop: posix keeps the process-group `SIGTERM -pid` and middleware drain; win32 keeps ctrlc, the `Y\n` stdin answer, the drain, and the `killTree` escalation. Whether to fold those into the resource as a termination-request parameter is left as a follow-up design question (it is also where #242's `[force]` symbol would plug in).

Public API and `Stdio` middleware semantics are unchanged, and the existing test suite passes as-is (36/36 × 3 runs; full platform matrix green). One corner case changes deliberately: a posix child that ignores SIGTERM and closes its stdio used to be silently leaked at teardown; the resource now holds the scope until the process actually closes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved process execution across POSIX and Windows environments.
  * Standardized handling of process output, errors, completion results, and termination.
  * Added more reliable cleanup when processes are stopped.
  * Improved support for processes with optional input and output streams.
  * Processes without required output streams now report a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->