### PR TITLE
🐛 Make `@effectionx/node` `once()` scope-bound

### DIFF
--- a/node/events.test.ts
+++ b/node/events.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { describe, it } from "@effectionx/vitest";
-import { type Operation, race, spawn } from "effection";
+import { type Operation, race, scoped, spawn, withResolvers } from "effection";
 import { expect } from "expect";
 
 import { type EventTargetLike, once } from "./events.ts";
@@ -94,6 +94,53 @@ describe("once", () => {
       emitter.emit("done");
 
       expect(emitter.listenerCount("done")).toBe(0);
+    });
+
+    it("removes the listener when its owning scope fails", function* () {
+      const emitter = new EventEmitter();
+      const failure = withResolvers<never>();
+      let registered = 0;
+      let caught: unknown;
+
+      try {
+        yield* scoped(function* () {
+          yield* spawn(function* () {
+            yield* once(emitter, "done");
+          });
+          yield* spawn(function* () {
+            registered = emitter.listenerCount("done");
+            failure.reject(new Error("boom"));
+          });
+          yield* failure.operation;
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect((caught as Error).message).toBe("boom");
+      expect(registered).toBe(1);
+      expect(emitter.listenerCount("done")).toBe(0);
+    });
+
+    it("ignores an event redelivered before its owner resumes", function* () {
+      const emitter = new EventEmitter();
+
+      const task = yield* spawn(function* () {
+        return yield* once<[string]>(emitter, "done");
+      });
+
+      yield* observe(() => {
+        let reentered = false;
+        emitter.on("done", () => {
+          if (!reentered) {
+            reentered = true;
+            emitter.emit("done", "second");
+          }
+        });
+        emitter.emit("done", "first");
+      });
+
+      expect(yield* task).toEqual(["first"]);
     });
 
     it("deregisters the losing branch of a race", function* () {

--- a/node/events.test.ts
+++ b/node/events.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from "node:events";
+import { describe, it } from "@effectionx/vitest";
+import { type Operation, race, spawn } from "effection";
+import { expect } from "expect";
+
+import { type EventTargetLike, once } from "./events.ts";
+
+/**
+ * A spawned task does not start until its parent suspends, so anything that
+ * has to happen while another task is registering its listener must run from
+ * inside a task of its own.
+ */
+function* observe<T>(read: () => T): Operation<T> {
+  const task = yield* spawn(function* () {
+    return read();
+  });
+  return yield* task;
+}
+
+/**
+ * `EventTarget` has no listener count, so count registrations ourselves.
+ */
+function createEventTarget(): EventTargetLike & {
+  listenerCount(): number;
+  dispatch(eventName: string): void;
+} {
+  const target = new EventTarget();
+  const listeners = new Set<(event: unknown) => void>();
+
+  return {
+    addEventListener(eventName, listener) {
+      listeners.add(listener);
+      target.addEventListener(eventName, listener as EventListener);
+    },
+    removeEventListener(eventName, listener) {
+      listeners.delete(listener);
+      target.removeEventListener(eventName, listener as EventListener);
+    },
+    listenerCount: () => listeners.size,
+    dispatch: (eventName) => void target.dispatchEvent(new Event(eventName)),
+  };
+}
+
+describe("once", () => {
+  describe("with an EventEmitter", () => {
+    it("registers nothing until it is interpreted", function* () {
+      const emitter = new EventEmitter();
+
+      once(emitter, "done");
+
+      expect(emitter.listenerCount("done")).toBe(0);
+    });
+
+    it("registers one listener and yields the event arguments", function* () {
+      const emitter = new EventEmitter();
+
+      const task = yield* spawn(function* () {
+        return yield* once<[number, string]>(emitter, "exit");
+      });
+
+      expect(yield* observe(() => emitter.listenerCount("exit"))).toBe(1);
+
+      emitter.emit("exit", 42, "SIGTERM");
+
+      expect(yield* task).toEqual([42, "SIGTERM"]);
+    });
+
+    it("removes the listener before its owner continues", function* () {
+      const emitter = new EventEmitter();
+
+      const task = yield* spawn(function* () {
+        yield* once(emitter, "done");
+        return emitter.listenerCount("done");
+      });
+
+      yield* observe(() => emitter.emit("done"));
+
+      expect(yield* task).toBe(0);
+    });
+
+    it("removes the listener when the interpreting task is halted", function* () {
+      const emitter = new EventEmitter();
+
+      const task = yield* spawn(function* () {
+        yield* once(emitter, "done");
+      });
+
+      expect(yield* observe(() => emitter.listenerCount("done"))).toBe(1);
+
+      yield* task.halt();
+
+      expect(emitter.listenerCount("done")).toBe(0);
+
+      emitter.emit("done");
+
+      expect(emitter.listenerCount("done")).toBe(0);
+    });
+
+    it("deregisters the losing branch of a race", function* () {
+      const emitter = new EventEmitter();
+      let racing = 0;
+
+      const value = yield* race([
+        once<[string]>(emitter, "loser"),
+        {
+          *[Symbol.iterator]() {
+            racing = emitter.listenerCount("loser");
+            return "won";
+          },
+        },
+      ]);
+
+      expect(value).toBe("won");
+      expect(racing).toBe(1);
+      expect(emitter.listenerCount("loser")).toBe(0);
+    });
+  });
+
+  describe("with an EventTarget", () => {
+    it("registers nothing until it is interpreted", function* () {
+      const target = createEventTarget();
+
+      once(target, "done");
+
+      expect(target.listenerCount()).toBe(0);
+    });
+
+    it("registers one listener and yields the event", function* () {
+      const target = createEventTarget();
+
+      const task = yield* spawn(function* () {
+        return yield* once<[Event]>(target, "done");
+      });
+
+      expect(yield* observe(() => target.listenerCount())).toBe(1);
+
+      target.dispatch("done");
+
+      const [event] = yield* task;
+      expect(event.type).toBe("done");
+      expect(target.listenerCount()).toBe(0);
+    });
+
+    it("removes the listener when the interpreting task is halted", function* () {
+      const target = createEventTarget();
+
+      const task = yield* spawn(function* () {
+        yield* once(target, "done");
+      });
+
+      expect(yield* observe(() => target.listenerCount())).toBe(1);
+
+      yield* task.halt();
+
+      expect(target.listenerCount()).toBe(0);
+
+      target.dispatch("done");
+
+      expect(target.listenerCount()).toBe(0);
+    });
+  });
+});

--- a/node/events.ts
+++ b/node/events.ts
@@ -109,6 +109,11 @@ export function on<T extends unknown[]>(
  * For EventEmitters, returns an array of arguments.
  * For EventTargets, returns a single-element array containing the event object.
  *
+ * The listener's lifetime is bound to the scope that interprets this operation,
+ * never to the event firing: constructing the operation registers nothing, and
+ * the listener is removed when the event arrives, the operation fails, or the
+ * scope is halted first.
+ *
  * @example
  * ```ts
  * import { once } from "@effectionx/node/events";
@@ -126,25 +131,31 @@ export function once<TArgs extends unknown[] = unknown[]>(
   target: EventSourceLike | null,
   eventName: string,
 ): Operation<TArgs> {
-  const result = withResolvers<TArgs>();
+  return {
+    *[Symbol.iterator]() {
+      const result = withResolvers<TArgs>();
 
-  if (target) {
-    if (isEventTarget(target)) {
-      // EventTarget style (DOM, web-worker self)
-      const listener = (event: unknown) => {
-        result.resolve([event] as TArgs);
-        target.removeEventListener(eventName, listener);
-      };
-      target.addEventListener(eventName, listener);
-    } else {
-      // EventEmitter style (Node.js)
-      const listener = (...args: unknown[]) => {
-        result.resolve(args as TArgs);
-        target.off(eventName, listener);
-      };
+      if (!target) {
+        return yield* result.operation;
+      }
+
+      if (isEventTarget(target)) {
+        const listener = (event: unknown) => result.resolve([event] as TArgs);
+        target.addEventListener(eventName, listener);
+        try {
+          return yield* result.operation;
+        } finally {
+          target.removeEventListener(eventName, listener);
+        }
+      }
+
+      const listener = (...args: unknown[]) => result.resolve(args as TArgs);
       target.on(eventName, listener);
-    }
-  }
-
-  return result.operation;
+      try {
+        return yield* result.operation;
+      } finally {
+        target.off(eventName, listener);
+      }
+    },
+  };
 }

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/node",
   "description": "Node.js stream and event emitter adapters for Effection",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "keywords": ["io", "streams"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/process/package.json
+++ b/process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/process",
   "description": "Spawn and manage child processes with structured concurrency",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/mod.js",

--- a/watch/package.json
+++ b/watch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@effectionx/watch",
   "description": "Run commands and restart them gracefully when source files change",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "keywords": ["process"],
   "type": "module",
   "main": "./dist/main.js",


### PR DESCRIPTION
Closes #251

# Motivation

`once()` from `@effectionx/node/events` registered its listener in the ordinary
function call, before returning the operation, and removed it only from inside
the listener itself. Two consequences:

- Constructing the operation registered a listener even if it was never
  interpreted.
- A halted scope left the listener attached. A losing `once()` branch in a
  `race()` is the common case: the race settles, the loser is halted, and its
  listener stays registered on the emitter, firing into a dead scope.

This contradicted the [Scope-Bound Event Registration policy](.policies/scope-bound-event-registration.md),
which names this operation as the compliant alternative to
`EventEmitter.prototype.once()`.

# Approach

`once()` now returns a reusable `{ *[Symbol.iterator]() }` operation. Nothing is
registered until it is interpreted; the listener is registered inside the
generator frame and removed in a synchronous `finally` around the wait, so it is
removed on the event, on failure, and on halt alike. Public shape is unchanged —
still an array of emitter arguments, or a single-element array holding the event
for `EventTarget`s — as is the null-target behaviour of suspending forever.

`node/events.test.ts` covers both source styles: construction registers nothing,
interpretation registers exactly one listener, the listener is gone before the
operation's owner continues, halting deregisters it, and a losing `race()` branch
is deregistered when the race settles. Five of the eight new tests fail against
the previous implementation.

Bumps `@effectionx/node` to 0.2.5. `workspace:*` is replaced with an exact
version at publish time, so `@effectionx/process` (0.8.3) and `@effectionx/watch`
(0.4.7) are bumped as well — without releases of their own the fix would not
reach consumers of those packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event-listener handling so listeners are registered only when needed and reliably removed when events complete, operations stop, or competing operations lose.
  * Ensured consistent behavior across supported event target types.

* **Tests**
  * Added coverage for listener registration, event delivery, cleanup, task interruption, and race conditions.

* **Chores**
  * Updated the package version to 0.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
